### PR TITLE
make s_require_peer's return value compatible

### DIFF
--- a/C/src/zre_interface.c
+++ b/C/src/zre_interface.c
@@ -241,6 +241,7 @@ s_require_peer (agent_t *self, char *identity, char *address, int port)
         zstr_sendm (self->pipe, "JOINED");
         zstr_send (self->pipe, identity);
     }
+    return peer;
 }
 
 


### PR DESCRIPTION
s_require_peer should return a peer, otherwise -werror compiler option will cause an error 
