### PR TITLE
Various changes to ensure connection with peers are stable

### DIFF
--- a/C/include/zre_msg.h
+++ b/C/include/zre_msg.h
@@ -34,16 +34,14 @@
         groups        strings 
         status        octet 
 
+    RESET - Tell peer to reset their connection to us.
+
     WHISPER - Send a message to a peer.
         cookies       frame 
 
     SHOUT - Send a message to a group.
         group         string 
         cookies       frame 
-
-    PING - Ping a peer that has gone silent.
-
-    PING_OK - Reply to a peer's ping.
 
     JOIN - Join a group.
         group         string 
@@ -52,17 +50,22 @@
     LEAVE - Leave a group.
         group         string 
         status        octet 
+
+    PING - Ping a peer that has gone silent.
+
+    PING_OK - Reply to a peer's ping.
 */
 
 #define ZRE_MSG_VERSION                     1
 
-#define ZRE_MSG_HELLO                       1
-#define ZRE_MSG_WHISPER                     2
-#define ZRE_MSG_SHOUT                       3
-#define ZRE_MSG_PING                        4
-#define ZRE_MSG_PING_OK                     5
-#define ZRE_MSG_JOIN                        6
-#define ZRE_MSG_LEAVE                       7
+#define ZRE_MSG_HELLO                       10
+#define ZRE_MSG_RESET                       11
+#define ZRE_MSG_WHISPER                     20
+#define ZRE_MSG_SHOUT                       21
+#define ZRE_MSG_JOIN                        22
+#define ZRE_MSG_LEAVE                       23
+#define ZRE_MSG_PING                        40
+#define ZRE_MSG_PING_OK                     41
 
 #ifdef __cplusplus
 extern "C" {

--- a/C/include/zre_peer.h
+++ b/C/include/zre_peer.h
@@ -43,11 +43,19 @@ void
 
 //  Connect peer mailbox
 void
-    zre_peer_connect (zre_peer_t *self, char *reply_to, char *address, int port);
+    zre_peer_connect (zre_peer_t *self, char *reply_to, char *endpoint);
+
+//  Connect peer mailbox
+void
+    zre_peer_disconnect (zre_peer_t *self);
 
 //  Return peer connected status
 bool
     zre_peer_connected (zre_peer_t *self);
+
+//  Return peer connection endpoint
+char *
+    zre_peer_endpoint (zre_peer_t *self);
 
 //  Send message to peer
 void
@@ -69,14 +77,6 @@ int64_t
 int64_t
     zre_peer_expired_at (zre_peer_t *self);
 
-//  Return peer ready flag
-bool
-    zre_peer_ready (zre_peer_t *self);
-    
-//  Set peer ready flag
-bool
-    zre_peer_ready_set (zre_peer_t *self, bool ready);
-
 //  Return peer status
 byte
     zre_peer_status (zre_peer_t *self);
@@ -85,6 +85,14 @@ byte
 void
     zre_peer_status_set (zre_peer_t *self, byte status);
 
+//  Return peer ready state
+byte
+    zre_peer_ready (zre_peer_t *self);
+    
+//  Set peer ready
+void
+    zre_peer_ready_set (zre_peer_t *self, bool ready);
+    
 #ifdef __cplusplus
 }
 #endif

--- a/C/model/zre_msg.xml
+++ b/C/model/zre_msg.xml
@@ -5,7 +5,7 @@ This is the ZRE protocol version 1.
 <!-- Protocol version -->
 <define name = "VERSION" value = "1" />
 
-<message name = "HELLO" id = "1">
+<message name = "HELLO" id = "10">
     <field name = "from" type = "string" />
     <field name = "port" type = "number" octets = "2" />
     <field name = "groups" type = "strings" />
@@ -13,35 +13,35 @@ This is the ZRE protocol version 1.
 Greet a peer so it connect back to us.
 </message>
 
-<message name = "WHISPER" id = "2">
+<message name = "WHISPER" id = "20">
     <field name = "cookies" type = "frame" />
 Send a message to a peer.
 </message>
 
-<message name = "SHOUT" id = "3">
+<message name = "SHOUT" id = "21">
     <field name = "group" type = "string" />
     <field name = "cookies" type = "frame" />
 Send a message to a group.
 </message>
 
-<message name = "PING" id = "4">
-Ping a peer that has gone silent.
-</message>
-
-<message name = "PING-OK" id = "5">
-Reply to a peer's ping.
-</message>
-
-<message name = "JOIN" id = "6">
+<message name = "JOIN" id = "22">
     <field name = "group" type = "string" />
     <field name = "status" type = "octet" />
 Join a group.
 </message>
 
-<message name = "LEAVE" id = "7">
+<message name = "LEAVE" id = "23">
     <field name = "group" type = "string" />
     <field name = "status" type = "octet" />
 Leave a group.
+</message>
+
+<message name = "PING" id = "40">
+Ping a peer that has gone silent.
+</message>
+
+<message name = "PING-OK" id = "41">
+Reply to a peer's ping.
 </message>
 
 </class>

--- a/C/src/zre_msg.c
+++ b/C/src/zre_msg.c
@@ -208,6 +208,9 @@ zre_msg_recv (void *socket)
             GET_OCTET (self->status);
             break;
 
+        case ZRE_MSG_RESET:
+            break;
+
         case ZRE_MSG_WHISPER:
             //  Get next frame, leave current untouched
             if (!zsocket_rcvmore (socket))
@@ -224,12 +227,6 @@ zre_msg_recv (void *socket)
             self->cookies = zframe_recv (socket);
             break;
 
-        case ZRE_MSG_PING:
-            break;
-
-        case ZRE_MSG_PING_OK:
-            break;
-
         case ZRE_MSG_JOIN:
             free (self->group);
             GET_STRING (self->group);
@@ -240,6 +237,12 @@ zre_msg_recv (void *socket)
             free (self->group);
             GET_STRING (self->group);
             GET_OCTET (self->status);
+            break;
+
+        case ZRE_MSG_PING:
+            break;
+
+        case ZRE_MSG_PING_OK:
             break;
 
         default:
@@ -294,6 +297,9 @@ zre_msg_send (zre_msg_t **self_p, void *socket)
             frame_size += 1;
             break;
             
+        case ZRE_MSG_RESET:
+            break;
+            
         case ZRE_MSG_WHISPER:
             break;
             
@@ -302,12 +308,6 @@ zre_msg_send (zre_msg_t **self_p, void *socket)
             frame_size++;       //  Size is one octet
             if (self->group)
                 frame_size += strlen (self->group);
-            break;
-            
-        case ZRE_MSG_PING:
-            break;
-            
-        case ZRE_MSG_PING_OK:
             break;
             
         case ZRE_MSG_JOIN:
@@ -326,6 +326,12 @@ zre_msg_send (zre_msg_t **self_p, void *socket)
                 frame_size += strlen (self->group);
             //  status is an octet
             frame_size += 1;
+            break;
+            
+        case ZRE_MSG_PING:
+            break;
+            
+        case ZRE_MSG_PING_OK:
             break;
             
         default:
@@ -360,6 +366,9 @@ zre_msg_send (zre_msg_t **self_p, void *socket)
             PUT_OCTET (self->status);
             break;
             
+        case ZRE_MSG_RESET:
+            break;
+            
         case ZRE_MSG_WHISPER:
             frame_flags = ZFRAME_MORE;
             break;
@@ -371,12 +380,6 @@ zre_msg_send (zre_msg_t **self_p, void *socket)
             else
                 PUT_OCTET (0);      //  Empty string
             frame_flags = ZFRAME_MORE;
-            break;
-            
-        case ZRE_MSG_PING:
-            break;
-            
-        case ZRE_MSG_PING_OK:
             break;
             
         case ZRE_MSG_JOIN:
@@ -395,6 +398,12 @@ zre_msg_send (zre_msg_t **self_p, void *socket)
             else
                 PUT_OCTET (0);      //  Empty string
             PUT_OCTET (self->status);
+            break;
+            
+        case ZRE_MSG_PING:
+            break;
+            
+        case ZRE_MSG_PING_OK:
             break;
             
     }
@@ -446,6 +455,9 @@ zre_msg_dup (zre_msg_t *self)
             copy->status = self->status;
             break;
 
+        case ZRE_MSG_RESET:
+            break;
+
         case ZRE_MSG_WHISPER:
             copy->cookies = zframe_dup (self->cookies);
             break;
@@ -453,12 +465,6 @@ zre_msg_dup (zre_msg_t *self)
         case ZRE_MSG_SHOUT:
             copy->group = strdup (self->group);
             copy->cookies = zframe_dup (self->cookies);
-            break;
-
-        case ZRE_MSG_PING:
-            break;
-
-        case ZRE_MSG_PING_OK:
             break;
 
         case ZRE_MSG_JOIN:
@@ -469,6 +475,12 @@ zre_msg_dup (zre_msg_t *self)
         case ZRE_MSG_LEAVE:
             copy->group = strdup (self->group);
             copy->status = self->status;
+            break;
+
+        case ZRE_MSG_PING:
+            break;
+
+        case ZRE_MSG_PING_OK:
             break;
 
     }
@@ -502,6 +514,10 @@ zre_msg_dump (zre_msg_t *self)
             }
             printf (" }\n");
             printf ("    status=%d\n", self->status);
+            break;
+            
+        case ZRE_MSG_RESET:
+            puts ("RESET:");
             break;
             
         case ZRE_MSG_WHISPER:
@@ -546,14 +562,6 @@ zre_msg_dump (zre_msg_t *self)
             printf ("    }\n");
             break;
             
-        case ZRE_MSG_PING:
-            puts ("PING:");
-            break;
-            
-        case ZRE_MSG_PING_OK:
-            puts ("PING_OK:");
-            break;
-            
         case ZRE_MSG_JOIN:
             puts ("JOIN:");
             if (self->group)
@@ -570,6 +578,14 @@ zre_msg_dump (zre_msg_t *self)
             else
                 printf ("    group=\n");
             printf ("    status=%d\n", self->status);
+            break;
+            
+        case ZRE_MSG_PING:
+            puts ("PING:");
+            break;
+            
+        case ZRE_MSG_PING_OK:
+            puts ("PING_OK:");
             break;
             
     }
@@ -622,23 +638,26 @@ zre_msg_command (zre_msg_t *self)
         case ZRE_MSG_HELLO:
             return ("HELLO");
             break;
+        case ZRE_MSG_RESET:
+            return ("RESET");
+            break;
         case ZRE_MSG_WHISPER:
             return ("WHISPER");
             break;
         case ZRE_MSG_SHOUT:
             return ("SHOUT");
             break;
-        case ZRE_MSG_PING:
-            return ("PING");
-            break;
-        case ZRE_MSG_PING_OK:
-            return ("PING_OK");
-            break;
         case ZRE_MSG_JOIN:
             return ("JOIN");
             break;
         case ZRE_MSG_LEAVE:
             return ("LEAVE");
+            break;
+        case ZRE_MSG_PING:
+            return ("PING");
+            break;
+        case ZRE_MSG_PING_OK:
+            return ("PING_OK");
             break;
     }
     return "?";
@@ -867,6 +886,13 @@ zre_msg_test (bool verbose)
     assert (zre_msg_status (self) == 123);
     zre_msg_destroy (&self);
 
+    self = zre_msg_new (ZRE_MSG_RESET);
+    zre_msg_send (&self, output);
+    
+    self = zre_msg_recv (input);
+    assert (self);
+    zre_msg_destroy (&self);
+
     self = zre_msg_new (ZRE_MSG_WHISPER);
     zre_msg_cookies_set (self, zframe_new ("Captcha Diem", 12));
     zre_msg_send (&self, output);
@@ -885,20 +911,6 @@ zre_msg_test (bool verbose)
     assert (self);
     assert (streq (zre_msg_group (self), "Life is short but Now lasts for ever"));
     assert (zframe_streq (zre_msg_cookies (self), "Captcha Diem"));
-    zre_msg_destroy (&self);
-
-    self = zre_msg_new (ZRE_MSG_PING);
-    zre_msg_send (&self, output);
-    
-    self = zre_msg_recv (input);
-    assert (self);
-    zre_msg_destroy (&self);
-
-    self = zre_msg_new (ZRE_MSG_PING_OK);
-    zre_msg_send (&self, output);
-    
-    self = zre_msg_recv (input);
-    assert (self);
     zre_msg_destroy (&self);
 
     self = zre_msg_new (ZRE_MSG_JOIN);
@@ -921,6 +933,20 @@ zre_msg_test (bool verbose)
     assert (self);
     assert (streq (zre_msg_group (self), "Life is short but Now lasts for ever"));
     assert (zre_msg_status (self) == 123);
+    zre_msg_destroy (&self);
+
+    self = zre_msg_new (ZRE_MSG_PING);
+    zre_msg_send (&self, output);
+    
+    self = zre_msg_recv (input);
+    assert (self);
+    zre_msg_destroy (&self);
+
+    self = zre_msg_new (ZRE_MSG_PING_OK);
+    zre_msg_send (&self, output);
+    
+    self = zre_msg_recv (input);
+    assert (self);
     zre_msg_destroy (&self);
 
     zctx_destroy (&ctx);


### PR DESCRIPTION
Mainly avoiding case where peer reconnects using old endpoint and starts sending out of order messages to a peer that's expecting HELLO.
