### PR TITLE
allow caller to supply zctx to zre_interface and zre_log classes

### DIFF
--- a/C/include/zre.h
+++ b/C/include/zre.h
@@ -44,6 +44,10 @@
 #   error "Zyre needs CZMQ/1.3.2 or later"
 #endif
 
+#ifdef interface
+#undef interface
+#endif
+
 #include <fmq.h>
 #if FMQ_VERSION < 10000
 #   error "Zyre needs FMQ/1.0.0 or later"

--- a/C/include/zre_interface.h
+++ b/C/include/zre_interface.h
@@ -35,7 +35,7 @@ typedef struct _zre_interface_t zre_interface_t;
 
 //  Constructor
 zre_interface_t *
-    zre_interface_new (void);
+    zre_interface_new (zctx_t *ctx);
 
 //  Destructor
 void

--- a/C/include/zre_log.h
+++ b/C/include/zre_log.h
@@ -35,7 +35,7 @@ typedef struct _zre_log_t zre_log_t;
 
 //  Constructor
 zre_log_t *
-    zre_log_new (char *endpoint);
+    zre_log_new (zctx_t *ctx, char *endpoint);
 
 //  Destructor
 void

--- a/C/src/zre_logger.c
+++ b/C/src/zre_logger.c
@@ -79,7 +79,7 @@ int main (int argc, char *argv [])
     int port = zsocket_bind (collector, "tcp://%s:*", host);
 
     //  Announce this to all peers we connect to
-    zre_interface_t *interface = zre_interface_new ();
+    zre_interface_t *interface = zre_interface_new (ctx);
     zre_interface_header_set (interface, "X-ZRELOG", "tcp://%s:%d", host, port);
 
     //  Get all log messages (don't filter)

--- a/C/src/zre_perf_local.c
+++ b/C/src/zre_perf_local.c
@@ -77,7 +77,7 @@ main (int argc, char *argv [])
     if (argc > 2)
         max_message = atoi (argv [2]);
 
-    zre_interface_t *interface = zre_interface_new ();
+    zre_interface_t *interface = zre_interface_new (NULL);
     zre_interface_join (interface, "GLOBAL");
 
     int64_t start = zclock_time ();

--- a/C/src/zre_perf_remote.c
+++ b/C/src/zre_perf_remote.c
@@ -34,7 +34,7 @@
 static void
 interface_task (void *args, zctx_t *ctx, void *pipe)
 {
-    zre_interface_t *interface = zre_interface_new ();
+    zre_interface_t *interface = zre_interface_new (NULL);
     int64_t counter = 0;
     char *to_peer = NULL;        //  Either of these set,
     char *to_group = NULL;       //    and we set a message

--- a/C/src/zre_ping.c
+++ b/C/src/zre_ping.c
@@ -29,7 +29,7 @@
 
 int main (int argc, char *argv [])
 {
-    zre_interface_t *interface = zre_interface_new ();
+    zre_interface_t *interface = zre_interface_new (NULL);
     zre_interface_join (interface, "GLOBAL");
 
     while (true) {


### PR DESCRIPTION
This patch attempts to mitigate the following:
when running zre_tester on Windows XP, one gets an "Address already in use" assertion even with just 10 simulated interfaces.

By sharing zctx_t objects, we reduce the number of threads created (originally 12 per simulated interface) and the accompanying socketpairs and avoid causing the assertion.

This does change the constructor signature.

If this is acceptable, a similar change could be made for fmq_server and fmq_client classes.
