### PR TITLE
fix for osx10.7 to define symbol ENONET as EHOSTDOWN

### DIFF
--- a/src/zre_udp.c
+++ b/src/zre_udp.c
@@ -47,6 +47,9 @@
 #   include <ws2tcpip.h>           // getnameinfo()
 #   include <iphlpapi.h>           // GetAdaptersAddresses()
 #endif
+#if defined (__APPLE__)
+#		define ENONET	EHOSTDOWN
+#endif
 
 //  Local functions
 
@@ -381,3 +384,4 @@ s_get_interface (zre_udp_t *self)
 #       error "Interface detection TBD on this operating system"
 #   endif
 }
+


### PR DESCRIPTION
Building zyre on osx10.7/clang gives the following error:

zre_udp.c:250:18: error: use of undeclared identifier 'ENONET'
    ||  errno == ENONET
                 ^
1 error generated.
make[2]: **\* [zre_udp.lo] Error 1

I've redefined ENONET symbol to fix this. Let me know if there's a better way to do this.
