### PR TITLE
Modified shout/whisper API

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -89,14 +89,25 @@ CZMQ_EXPORT int
 CZMQ_EXPORT zmsg_t *
     zyre_recv (zyre_t *self);
 
-//  Send message to single peer; peer ID is first frame in message
+//  Send message to single peer, specified as a UUID string
 //  Destroys message after sending
 CZMQ_EXPORT int
-    zyre_whisper (zyre_t *self, zmsg_t **msg_p);
+    zyre_whisper (zyre_t *self, char *peer, zmsg_t **msg_p);
 
-//  Send message to a group of peers
+//  Send message to a named group
+//  Destroys message after sending
 CZMQ_EXPORT int
-    zyre_shout (zyre_t *self, zmsg_t **msg_p);
+    zyre_shout (zyre_t *self, char *group, zmsg_t **msg_p);
+
+//  Send string to single peer specified as a UUID string.
+//  String is formatted using printf specifiers.
+CZMQ_EXPORT int
+    zyre_whispers (zyre_t *self, char *peer, char *format, ...);
+
+//  Send message to a named group
+//  Destroys message after sending
+CZMQ_EXPORT int
+    zyre_shouts (zyre_t *self, char *group, char *format, ...);
 
 //  Return handle to the Zyre node, for polling
 CZMQ_EXPORT void *

--- a/include/zyre_event.h
+++ b/include/zyre_event.h
@@ -57,16 +57,6 @@ CZMQ_EXPORT void
 CZMQ_EXPORT zyre_event_t *
     zyre_event_recv (zyre_t *self);
 
-//  Sends a zyre whisper. Returns 0 if succesful else 1.
-//  Destroys msg after sending
-CZMQ_EXPORT int
-    zyre_event_send_whisper (zyre_t *zyre, zmsg_t *msg, char *receiver);
-
-//  Sends a zyre shout. Returns 0 if succesful else 1.
-//  Destroys msg after sending
-CZMQ_EXPORT int
-    zyre_event_send_shout (zyre_t *zyre, zmsg_t *msg, char *group);
-
 //  Returns event type, which is a zyre_event_type_t
 CZMQ_EXPORT zyre_event_type_t
     zyre_event_type (zyre_event_t *self);

--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -30,11 +30,6 @@
     work that you will want to do in many cases, such as unpacking the peer
     headers for each ENTER event received.
 @discuss
-    Sending via zyre_event_t might be cumbersome. Alternatively we could use
-    zyre_event_whisper (zmsg, recevier_uuid) and 
-    zyre_event_shout (zmsg, group_name)
-
-    Also we should deliver all of the payload frames.
 @end
 */
 
@@ -135,37 +130,6 @@ zyre_event_recv (zyre_t *self)
     return event;
 }
 
-//  ---------------------------------------------------------------------
-//  Sends an zyre whisper. Returns 0 if succesful else 1.
-//  Destroys msg after sending
-
-int
-zyre_event_send_whisper (zyre_t *zyre, zmsg_t *msg, char *receiver) 
-{
-    assert (zyre);
-    assert (msg);
-
-    zmsg_pushstr (msg, receiver);
-    int rc = zyre_whisper (zyre, &msg); 
-    zmsg_destroy (&msg);
-    return rc;
-}
-
-//  ---------------------------------------------------------------------
-//  Sends an zyre shout. Returns 0 if succesful else 1.
-//  Destroys msg after sending
-
-int
-zyre_event_send_shout (zyre_t *zyre, zmsg_t *msg, char *group)
-{
-    assert (zyre);
-    assert (msg);
-    
-    zmsg_pushstr (msg, group);
-    int rc = zyre_shout (zyre, &msg);
-    zmsg_destroy (&msg);
-    return rc;
-}
 
 //  ---------------------------------------------------------------------
 //  Returns event type, which is a zyre_event_type_t
@@ -257,7 +221,7 @@ zyre_event_test (bool verbose)
     //  One node shouts to GLOBAL
     zmsg_t *msg = zmsg_new ();
     zmsg_addstr (msg, "Hello, World");
-    zyre_event_send_shout (node1, msg, "GLOBAL");
+    zyre_shout (node1, "GLOBAL", &msg);
 
     //  Parse ENTER
     zyre_event_t *zyre_event = zyre_event_recv (node2);

--- a/tools/perf_local.c
+++ b/tools/perf_local.c
@@ -129,11 +129,7 @@ main (int argc, char *argv [])
     //  send WHISPER message
     start = zclock_time ();
     for (nbr_message = 0; nbr_message < max_message; nbr_message++) {
-        zmsg_t *outgoing = zmsg_new ();
-        zmsg_addstr (outgoing, peers [nbr_message % max_node]);
-        zmsg_addstr (outgoing, "S:WHISPER");
-        zyre_whisper (node, &outgoing);
-
+        zyre_whispers (node, peers [nbr_message % max_node], "S:WHISPER");
         while (zmq_poll (pollitems, 1, 0) > 0) {
             if (s_node_recv (node, "WHISPER", "R:WHISPER"))
                 nbr_message_response++;
@@ -156,11 +152,7 @@ main (int argc, char *argv [])
     max_message = max_message / max_node;
 
     for (nbr_message = 0; nbr_message < max_message; nbr_message++) {
-        zmsg_t *outgoing = zmsg_new ();
-        zmsg_addstr (outgoing, "GLOBAL");
-        zmsg_addstr (outgoing, "S:SHOUT");
-        zyre_shout (node, &outgoing);
-
+        zyre_shouts (node, "GLOBAL", "S:SHOUT");
         while (zmq_poll (pollitems, 1, 0) > 0) {
             if (s_node_recv (node, "SHOUT", "R:SHOUT"))
                 nbr_message_response++;

--- a/tools/perf_remote.c
+++ b/tools/perf_remote.c
@@ -113,18 +113,12 @@ node_task (void *args, zctx_t *ctx, void *pipe)
 
             //  Send outgoing messages if needed
             if (to_peer) {
-                zmsg_t *outgoing = zmsg_new ();
-                zmsg_addstr (outgoing, to_peer);
-                zmsg_addstr (outgoing, sending_cookie);
-                zyre_whisper (node, &outgoing);
+                zyre_whispers (node, to_peer, sending_cookie);
                 free (to_peer);
                 to_peer = NULL;
             }
             if (to_group) {
-                zmsg_t *outgoing = zmsg_new ();
-                zmsg_addstr (outgoing, to_group);
-                zmsg_addstr (outgoing, sending_cookie);
-                zyre_shout (node, &outgoing);
+                zyre_shouts (node, to_group, sending_cookie);
                 free (to_group);
                 to_group = NULL;
             }

--- a/tools/zpinger.c
+++ b/tools/zpinger.c
@@ -44,10 +44,7 @@ int main (int argc, char *argv [])
         if (streq (event, "ENTER")) {
             char *peer = zmsg_popstr (incoming);
             printf ("I: [%s] peer entered\n", peer);
-            zmsg_t *outgoing = zmsg_new ();
-            zmsg_addstr (outgoing, peer);
-            zmsg_addstr (outgoing, "Hello");
-            zyre_whisper (node, &outgoing);
+            zyre_whispers (node, peer, "Hello");
             free (peer);
         }
         else
@@ -61,10 +58,7 @@ int main (int argc, char *argv [])
             char *peer = zmsg_popstr (incoming);
             printf ("I: [%s] received ping (WHISPER)\n", peer);
             free (peer);
-            zmsg_t *outgoing = zmsg_new ();
-            zmsg_addstr (outgoing, "GLOBAL");
-            zmsg_addstr (outgoing, "Hello");
-            zyre_shout (node, &outgoing);
+            zyre_shouts (node, "GLOBAL", "Hello");
         }
         else
         if (streq (event, "SHOUT")) {

--- a/tools/ztester.c
+++ b/tools/ztester.c
@@ -125,18 +125,12 @@ node_task (void *args, zctx_t *ctx, void *pipe)
 
             //  Send outgoing messages if needed
             if (to_peer) {
-                zmsg_t *outgoing = zmsg_new ();
-                zmsg_addstr (outgoing, to_peer);
-                zmsg_addstr (outgoing, "%lu", counter++);
-                zyre_whisper (node, &outgoing);
+                zyre_whispers (node, to_peer, "%lu", counter++);
                 free (to_peer);
                 to_peer = NULL;
             }
             if (to_group) {
-                zmsg_t *outgoing = zmsg_new ();
-                zmsg_addstr (outgoing, to_group);
-                zmsg_addstr (outgoing, "%lu", counter++);
-                zyre_shout (node, &outgoing);
+                zyre_shouts (node, to_group, "%lu", counter++);
                 free (to_group);
                 to_group = NULL;
             }


### PR DESCRIPTION
- removed zyre_event_send_shout/whisper which was redundent with
  zyre_shout/whisper
- changed zyre_shout/whisper to take peer/group name as second
  argument, as string, rather than as message
- added zyre_shouts/whispers to send string to peer/group in a
  single step, which is the 90% use case
- modified all test tools to use string sending methods

Notes
- when a method uses class X as first argument that means the method
  lives inside class X, thus zyre_whisper (zyre_t *self,...)
