### PR TITLE
Added test if ZRE_DISCOVERY_PORT/udp is open

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -43,6 +43,7 @@
 
 //  IANA-assigned port for ZYRE discovery protocol
 #define ZRE_DISCOVERY_PORT  5670
+#define ZRE_DISCOVERY_PORT_TEST_TIMEOUT 1000
 
 //  The public API consists of the "zyre_t" class
 

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -85,9 +85,16 @@ zyre_new (zctx_t *ctx)
     self->pipe = zthread_fork (ctx, zyre_node_engine, NULL);
     if (self->pipe) {
         char *status = zstr_recv (self->pipe);
-        if (strneq (status, "OK"))
-            zyre_destroy (&self);
-        zstr_free (&status);
+        if (streq (status, "OK")) {
+          zstr_free (&status);
+        } else if (streq (status, "TERM")) {
+          zstr_free (&status);
+          free (self);
+          self = NULL;
+        } else {
+          zyre_destroy (&self);
+          zstr_free (&status);
+        }
     }
     else {
         free (self);


### PR DESCRIPTION
Hi all,

While using zyre, i found out that there is no detection, if port 5670/udp is open or not. With following changes, where i added check, if  ZRE_DISCOVERY_PORT/udp port is open

One can test it with following code:

```
  zctx_t *ctx = zctx_new();
  zyre_t *node1 = zyre_new(ctx);
  printf("Node pointer is %p \n",node1);
```

when user runs it and port is closed, user would see and node1 pointer will be null:

```
mvala@vala ~ $ /home/mvala/test/bin/test/zt-test-zyre
14-03-18 11:55:31 E: Discovery is not possible !!!
14-03-18 11:55:31 E: Make sure that port 5670/udp is open !!!
Node pointer is (nil) 
```

if port is open

```
mvala@vala ~ $ /home/mvala/test/bin/test/zt-test-zyre
Node pointer is 0x9ab0b0 
```

Ciao

Martin
