### PR TITLE
Added CZMQ_EXPORTs for compiling for windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ set (zyre_sources
 )
 source_group ("Source Files" FILES ${zyre_sources})
 add_library(zyre SHARED ${zyre_sources})
-set_target_properties(zyre PROPERTIES DEFINE_SYMBOL "LIBZYRE_EXPORTS")
+set_target_properties(zyre PROPERTIES DEFINE_SYMBOL "LIBCZMQ_EXPORTS")
 target_link_libraries(zyre ${CZMQ_LIBRARIES} ${ZEROMQ_LIBRARIES} ${MORE_LIBRARIES})
 
 install(TARGETS zyre

--- a/include/zre_log_msg.h
+++ b/include/zre_log_msg.h
@@ -177,7 +177,7 @@ void
     zre_log_msg_set_data (zre_log_msg_t *self, const char *format, ...);
 
 //  Self test of this class
-int
+CZMQ_EXPORT int
     zre_log_msg_test (bool verbose);
 //  @end
 

--- a/include/zre_msg.h
+++ b/include/zre_msg.h
@@ -283,7 +283,7 @@ void
     zre_msg_set_group (zre_msg_t *self, const char *format, ...);
 
 //  Self test of this class
-int
+CZMQ_EXPORT int
     zre_msg_test (bool verbose);
 //  @end
 

--- a/model/build-cmake.gsl
+++ b/model/build-cmake.gsl
@@ -99,7 +99,7 @@ set (zyre_sources
 )
 source_group ("Source Files" FILES ${zyre_sources})
 add_library($(project.name) SHARED ${zyre_sources})
-set_target_properties($(project.name) PROPERTIES DEFINE_SYMBOL "LIBZYRE_EXPORTS")
+set_target_properties($(project.name) PROPERTIES DEFINE_SYMBOL "LIBCZMQ_EXPORTS")
 target_link_libraries($(project.name) ${CZMQ_LIBRARIES} ${ZEROMQ_LIBRARIES} ${MORE_LIBRARIES})
 
 install(TARGETS $(project.name)

--- a/src/zyre_group.h
+++ b/src/zyre_group.h
@@ -54,7 +54,7 @@ void
     zyre_group_send (zyre_group_t *self, zre_msg_t **msg_p);
 
 //  Self test of this class
-void
+CZMQ_EXPORT void
     zyre_group_test (bool verbose);
     
 #ifdef __cplusplus

--- a/src/zyre_node.h
+++ b/src/zyre_node.h
@@ -39,7 +39,7 @@ void
     zyre_node_engine (void *args, zctx_t *ctx, void *pipe);
 
 //  Self test of this class
-void
+CZMQ_EXPORT void
     zyre_node_test (bool verbose);
 
 #ifdef __cplusplus

--- a/src/zyre_peer.h
+++ b/src/zyre_peer.h
@@ -110,7 +110,7 @@ void
     zyre_peer_set_log (zyre_peer_t *self, zyre_log_t *log);
 
 //  Self test of this class
-void
+CZMQ_EXPORT void
     zyre_peer_test (bool verbose);
 
 #ifdef __cplusplus


### PR DESCRIPTION
I have added CZMQ_EXPORT statements also to the generated `zre_msg.h` and `zre_log_msg.h`, but the correct place is of course in the corresponding templates. CZMQ_EXPORT should likely be added to all generated functions.
