### PR TITLE
Change ready status to false when peer is doing disconnect

### DIFF
--- a/src/zyre_peer.c
+++ b/src/zyre_peer.c
@@ -147,6 +147,7 @@ zyre_peer_disconnect (zyre_peer_t *self)
         self->mailbox = NULL;
         self->endpoint = NULL;
         self->connected = false;
+        self->ready = false;
     }
 }
 


### PR DESCRIPTION
Shouldn't we set ready state to false? when disconnecting?
