### PR TITLE
Moved Zyre to actor model

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -37,8 +37,8 @@
     ZYRE_MAKE_VERSION(ZYRE_VERSION_MAJOR, ZYRE_VERSION_MINOR, ZYRE_VERSION_PATCH)
 
 #include <czmq.h>
-#if CZMQ_VERSION < 20200
-#   error "Zyre needs CZMQ/2.2.0 or later"
+#if CZMQ_VERSION < 30000
+#   error "Zyre needs CZMQ/3.0.0 or later"
 #endif
 
 //  IANA-assigned port for ZYRE discovery protocol
@@ -56,7 +56,7 @@ typedef struct _zyre_t zyre_t;
 //  Constructor, creates a new Zyre node. Note that until you start the
 //  node it is silent and invisible to other nodes on the network.
 CZMQ_EXPORT zyre_t *
-    zyre_new (zctx_t *ctx);
+    zyre_new (void);
 
 //  Destructor, destroys a Zyre node. When you destroy a node, any
 //  messages it is sending or receiving will be discarded.
@@ -132,8 +132,8 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zyre_shouts (zyre_t *self, char *group, char *format, ...);
 
-//  Return handle to the Zyre node, for polling
-CZMQ_EXPORT void *
+//  Return socket for talking to the Zyre node, for polling
+CZMQ_EXPORT zsock_t *
     zyre_socket (zyre_t *self);
 
 //  Prints zyre information

--- a/include/zyre_log.h
+++ b/include/zyre_log.h
@@ -36,7 +36,7 @@ typedef struct _zyre_log_t zyre_log_t;
 // @interface
 //  Constructor
 CZMQ_EXPORT zyre_log_t *
-    zyre_log_new (zctx_t *ctx, const char *sender);
+    zyre_log_new (const char *sender);
 
 //  Destructor
 CZMQ_EXPORT void

--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -99,6 +99,9 @@ zyre_event_new (zyre_t *node)
         self->msg = msg;
         msg = NULL;
     }
+    else
+        printf ("???? %s\n", type);
+    
     free (type);
     zmsg_destroy (&msg);
     return self;
@@ -210,16 +213,16 @@ zyre_event_test (bool verbose)
     printf (" * zyre_event: ");
 
     //  @selftest
-    zctx_t *ctx = zctx_new ();
     //  Create two nodes
-    zyre_t *node1 = zyre_new (ctx);
-    zyre_t *node2 = zyre_new (ctx);
+    zyre_t *node1 = zyre_new ();
+    zyre_t *node2 = zyre_new ();
     zyre_set_header (node1, "X-HELLO", "World");
     zyre_start (node1);
     zyre_start (node2);
+    zyre_set_verbose (node1);
+    zyre_set_verbose (node2);
     zyre_join (node1, "GLOBAL");
     zyre_join (node2, "GLOBAL");
-
     //  Give time for them to interconnect
     zclock_sleep (250);
 
@@ -227,6 +230,7 @@ zyre_event_test (bool verbose)
     zmsg_t *msg = zmsg_new ();
     zmsg_addstr (msg, "Hello, World");
     zyre_shout (node1, "GLOBAL", &msg);
+    zclock_sleep (100);
 
     //  Parse ENTER
     zyre_event_t *event = zyre_event_new (node2);
@@ -235,8 +239,8 @@ zyre_event_test (bool verbose)
     assert (sender);
     char *address = zyre_event_address (event);
     assert (address);
-    assert (streq (zyre_event_header (event, "X-HELLO"), "World"));
-    msg = zyre_event_msg (event);
+    char *header = zyre_event_header (event, "X-HELLO");
+    assert (header);
     zyre_event_destroy (&event);
     
     //  Parse JOIN
@@ -256,7 +260,6 @@ zyre_event_test (bool verbose)
     
     zyre_destroy (&node1);
     zyre_destroy (&node2);
-    zctx_destroy (&ctx);
     //  @end
     printf ("OK\n");
 }

--- a/src/zyre_group.c
+++ b/src/zyre_group.c
@@ -136,9 +136,8 @@ void
 zyre_group_test (bool verbose)
 {
     printf (" * zyre_group: ");
-    zctx_t *ctx = zctx_new ();
-    void *mailbox = zsocket_new (ctx, ZMQ_DEALER);
-    zsocket_bind (mailbox, "tcp://127.0.0.1:5555");
+    zsock_t *mailbox = zsock_new (ZMQ_DEALER);
+    zsock_bind (mailbox, "tcp://127.0.0.1:5552");
 
     zhash_t *groups = zhash_new ();
     zyre_group_t *group = zyre_group_new ("tests", groups);
@@ -146,9 +145,9 @@ zyre_group_test (bool verbose)
     zhash_t *peers = zhash_new ();
     zuuid_t *you = zuuid_new ();
     zuuid_t *me = zuuid_new ();
-    zyre_peer_t *peer = zyre_peer_new (ctx, peers, you);
+    zyre_peer_t *peer = zyre_peer_new (peers, you);
     assert (!zyre_peer_connected (peer));
-    zyre_peer_connect (peer, me, "tcp://127.0.0.1:5555");
+    zyre_peer_connect (peer, me, "tcp://127.0.0.1:5552");
     assert (zyre_peer_connected (peer));
 
     zyre_group_join (group, peer);
@@ -167,7 +166,7 @@ zyre_group_test (bool verbose)
     zuuid_destroy (&you);
     zhash_destroy (&peers);
     zhash_destroy (&groups);
-    zctx_destroy (&ctx);
+    zsock_destroy (&mailbox);
     printf ("OK\n");
 }
 

--- a/src/zyre_node.h
+++ b/src/zyre_node.h
@@ -33,10 +33,10 @@ extern "C" {
 
 typedef struct _zyre_node_t zyre_node_t;
 
-//  This is the engine that runs a single node; it uses one thread, creates
+//  This is the actor that runs a single node; it uses one thread, creates
 //  a zyre_node object at start and destroys that when finishing.
 void
-    zyre_node_engine (void *args, zctx_t *ctx, void *pipe);
+    zyre_node_actor (zsock_t *pipe, void *args);
 
 //  Self test of this class
 CZMQ_EXPORT void

--- a/src/zyre_peer.h
+++ b/src/zyre_peer.h
@@ -35,7 +35,7 @@ typedef struct _zyre_peer_t zyre_peer_t;
 
 //  Constructor
 zyre_peer_t *
-    zyre_peer_new (zctx_t *ctx, zhash_t *container, zuuid_t *uuid);
+    zyre_peer_new (zhash_t *container, zuuid_t *uuid);
 
 //  Destructor
 void

--- a/tools/perf_remote.c
+++ b/tools/perf_remote.c
@@ -32,130 +32,122 @@
 #define MAX_GROUP 10
 
 static void
-node_task (void *args, zctx_t *ctx, void *pipe)
+node_actor (zsock_t *pipe, void *args)
 {
-    zyre_t *node = zyre_new (ctx);
+    zyre_t *node = zyre_new ();
     zyre_start (node);
+    zsock_signal (pipe);
+    
     char *to_peer = NULL;        //  Either of these set,
     char *to_group = NULL;       //    and we set a message
     char *cookie = NULL;         //  received message
     char *sending_cookie = NULL; //  sending message
-    
-    zmq_pollitem_t pollitems [] = {
-        { pipe, 0, ZMQ_POLLIN, 0 },
-        { zyre_socket (node), 0, ZMQ_POLLIN, 0 }
-    };
 
-    // all node joins GLOBAL
+    zpoller_t *poller = zpoller_new (pipe, zyre_socket (node), NULL);
     zyre_join (node, "GLOBAL");
+    
+    while (!zsys_interrupted) {
+        void *which = zpoller_wait (poller, randof (1000));
+        if (which == pipe || which == NULL)
+            break;              //  Any command from parent means exit
 
-    while (!zctx_interrupted) {
-        if (zmq_poll (pollitems, 2, randof (1000) * ZMQ_POLL_MSEC) == -1)
+        zmsg_t *incoming = zyre_recv (node);
+        if (!incoming)
             break;              //  Interrupted
 
-        if (pollitems [0].revents & ZMQ_POLLIN)
-            break;              //  Any command from parent means EXIT
+        char *event = zmsg_popstr (incoming);
+        if (streq (event, "ENTER")) {
+            //  Always say hello to new peer
+            to_peer = zmsg_popstr (incoming);
+            sending_cookie = "R:HELLO";
+        }
+        else
+        if (streq (event, "EXIT"))
+            ;   //  Do nothing
+        else
+        if (streq (event, "WHISPER")) {
+            to_peer = zmsg_popstr (incoming);
+            cookie = zmsg_popstr (incoming);
 
-        //  Process an event from node
-        if (pollitems [1].revents & ZMQ_POLLIN) {
-            zmsg_t *incoming = zyre_recv (node);
-            if (!incoming)
-                break;              //  Interrupted
-
-            char *event = zmsg_popstr (incoming);
-            if (streq (event, "ENTER")) {
-                //  Always say hello to new peer
-                to_peer = zmsg_popstr (incoming);
-                sending_cookie = "R:HELLO";
-            }
-            else
-            if (streq (event, "EXIT")) {
-                //  Do nothing
-            }
-            else
-            if (streq (event, "WHISPER")) {
-                to_peer = zmsg_popstr (incoming);
-                cookie = zmsg_popstr (incoming);
-
-                // if a message comes from perf_local, send back a special response
-                if (streq (cookie, "S:WHISPER")) {
-                    sending_cookie = "R:WHISPER";
-                }
-                else {
-                    free (to_peer);
-                    free (cookie);
-                    to_peer = NULL;
-                    cookie = NULL;
-                }
-            }
-            else
-            if (streq (event, "SHOUT")) {
-                to_peer = zmsg_popstr (incoming);
-                to_group = zmsg_popstr (incoming);
-                cookie = zmsg_popstr (incoming);
-
-                // if a message comes from perf_local, send back a special response
-                if (streq (cookie, "S:SHOUT")) {
-                    free (to_peer);
-                    to_peer = NULL;
-                    sending_cookie = "R:SHOUT";
-                }
-                else {
-                    free (to_peer);
-                    free (to_group);
-                    to_peer = NULL;
-                    to_group = NULL;
-                }
-            }
-            free (event);
-            zmsg_destroy (&incoming);
-
-            //  Send outgoing messages if needed
-            if (to_peer) {
-                zyre_whispers (node, to_peer, sending_cookie);
+            //  If a message comes from perf_local,
+            //  send back a special response
+            if (streq (cookie, "S:WHISPER"))
+                sending_cookie = "R:WHISPER";
+            else {
                 free (to_peer);
-                to_peer = NULL;
-            }
-            if (to_group) {
-                zyre_shouts (node, to_group, sending_cookie);
-                free (to_group);
-                to_group = NULL;
-            }
-            if (cookie) {
                 free (cookie);
+                to_peer = NULL;
                 cookie = NULL;
             }
         }
+        else
+        if (streq (event, "SHOUT")) {
+            to_peer = zmsg_popstr (incoming);
+            to_group = zmsg_popstr (incoming);
+            cookie = zmsg_popstr (incoming);
+
+            //  If a message comes from perf_local,
+            //  send back a special response
+            if (streq (cookie, "S:SHOUT")) {
+                free (to_peer);
+                to_peer = NULL;
+                sending_cookie = "R:SHOUT";
+            }
+            else {
+                free (to_peer);
+                free (to_group);
+                to_peer = NULL;
+                to_group = NULL;
+            }
+        }
+        free (event);
+        zmsg_destroy (&incoming);
+
+        //  Send outgoing messages if needed
+        if (to_peer) {
+            zyre_whispers (node, to_peer, sending_cookie);
+            free (to_peer);
+            to_peer = NULL;
+        }
+        if (to_group) {
+            zyre_shouts (node, to_group, sending_cookie);
+            free (to_group);
+            to_group = NULL;
+        }
+        if (cookie) {
+            free (cookie);
+            cookie = NULL;
+        }
     }
+    zpoller_destroy (&poller);
     zyre_destroy (&node);
 }
 
 
 int main (int argc, char *argv [])
 {
-    //  Initialize context for talking to tasks
-    zctx_t *ctx = zctx_new ();
-    zctx_set_linger (ctx, 100);
-    
     //  Get number of nodes to simulate, default 100
     int max_node = 100;
-    int nbr_node = 0;
     if (argc > 1)
         max_node = atoi (argv [1]);
 
     //  We address nodes as an array of pipes
-    void **pipes = zmalloc (sizeof (void *) * max_node);
+    void **nodes = zmalloc (sizeof (zactor_t *) * max_node);
 
-    for (nbr_node = 0; nbr_node < max_node; nbr_node++) {
-        pipes [nbr_node] = zthread_fork (ctx, node_task, NULL);
-        zclock_log ("I: Started node (%d running)", nbr_node + 1);
+    int node_nbr;
+    for (node_nbr = 0; node_nbr < max_node; node_nbr++) {
+        nodes [node_nbr] = zactor_new (node_actor, NULL);
+        zclock_log ("I: Started node %d", node_nbr + 1);
     }
     //  We will randomly start and stop node threads
-    while (!zctx_interrupted) {
+    while (!zsys_interrupted)
         zclock_sleep (1000);
+
+    for (node_nbr = 0; node_nbr < max_node; node_nbr++) {
+        zclock_log ("I: Stopped node %d", node_nbr + 1);
+        zactor_destroy (nodes [node_nbr]);
     }
     zclock_log ("I: Stopped perl_remote");
-    zctx_destroy (&ctx);
-    free (pipes);
+    free (nodes);
     return 0;
 }

--- a/tools/zpinger.c
+++ b/tools/zpinger.c
@@ -29,8 +29,7 @@
 
 int main (int argc, char *argv [])
 {
-    zctx_t *ctx = zctx_new ();
-    zyre_t *node = zyre_new (ctx);
+    zyre_t *node = zyre_new ();
     zyre_start (node);
     zyre_join (node, "GLOBAL");
 
@@ -72,6 +71,5 @@ int main (int argc, char *argv [])
         zmsg_destroy (&incoming);
     }
     zyre_destroy (&node);
-    zctx_destroy (&ctx);
     return 0;
 }


### PR DESCRIPTION
This breaks the zyre_new API but otherwise is compatible. Zyre now
uses the CZMQ zactor model instead of its zthread model.
