### PR TITLE
Problem: need to know if zyre_start() failed

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -25,7 +25,7 @@ SUFFIXES=.txt .xml .1 .3 .7
 .txt.xml:
 	$(srcdir)/mkman $<
 	asciidoc -d manpage -b docbook -f  $(srcdir)/asciidoc.conf \
-		-azre_version=@PACKAGE_VERSION@ -o$@ $<
+		-azyre_version=@PACKAGE_VERSION@ -o$@ $<
 .xml.1:
 	xmlto man $<
 .xml.3:

--- a/doc/zre_log_msg.txt
+++ b/doc/zre_log_msg.txt
@@ -21,14 +21,14 @@ CZMQ_EXPORT void
 //  ZMQ_ROUTER, then parses the first frame as a routing_id. Destroys msg
 //  and nullifies the msg refernce.
 CZMQ_EXPORT zre_log_msg_t *
-    zre_log_msg_decode (zmsg_t **msg_p, int socket_type);
+    zre_log_msg_decode (zmsg_t **msg_p);
 
 //  Encode zre_log_msg into zmsg and destroy it. Returns a newly created
 //  object or NULL if error. Use when not in control of sending the message.
 //  If the socket_type is ZMQ_ROUTER, then stores the routing_id as the
 //  first frame of the resulting message.
 CZMQ_EXPORT zmsg_t *
-    zre_log_msg_encode (zre_log_msg_t *self, int socket_type);
+    zre_log_msg_encode (zre_log_msg_t **self_p);
 
 //  Receive and parse a zre_log_msg from the socket. Returns new object, 
 //  or NULL if error. Will block if there's no message waiting.
@@ -48,7 +48,19 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zre_log_msg_send_again (zre_log_msg_t *self, void *output);
 
+//  Encode the LOG 
+CZMQ_EXPORT zmsg_t *
+    zre_log_msg_encode_log (
+        byte level,
+        byte event,
+        uint16_t node,
+        uint16_t peer,
+        uint64_t time,
+        const char *data);
+
+
 //  Send the LOG to the output in one step
+//  WARNING, this call will fail if output is of type ZMQ_ROUTER.
 CZMQ_EXPORT int
     zre_log_msg_send_log (void *output,
         byte level,
@@ -64,7 +76,7 @@ CZMQ_EXPORT zre_log_msg_t *
 
 //  Print contents of message to stdout
 CZMQ_EXPORT void
-    zre_log_msg_dump (zre_log_msg_t *self);
+    zre_log_msg_print (zre_log_msg_t *self);
 
 //  Get/set the message routing id
 CZMQ_EXPORT zframe_t *
@@ -137,17 +149,14 @@ EXAMPLE
     zre_log_msg_destroy (&self);
 
     //  Create pair of sockets we can send through
-    zctx_t *ctx = zctx_new ();
-    assert (ctx);
-
-    void *output = zsocket_new (ctx, ZMQ_DEALER);
-    assert (output);
-    zsocket_bind (output, "inproc://selftest");
-
-    void *input = zsocket_new (ctx, ZMQ_ROUTER);
+    zsock_t *input = zsock_new (ZMQ_ROUTER);
     assert (input);
-    zsocket_connect (input, "inproc://selftest");
-    
+    zsock_connect (input, "inproc://selftest-zre_log_msg");
+
+    zsock_t *output = zsock_new (ZMQ_DEALER);
+    assert (output);
+    zsock_bind (output, "inproc://selftest-zre_log_msg");
+
     //  Encode/send/decode and verify each message type
     int instance;
     zre_log_msg_t *copy;
@@ -182,6 +191,7 @@ EXAMPLE
         zre_log_msg_destroy (&self);
     }
 
-    zctx_destroy (&ctx);
+    zsock_destroy (&input);
+    zsock_destroy (&output);
 ----
 

--- a/doc/zyre.txt
+++ b/doc/zyre.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 //  Constructor, creates a new Zyre node. Note that until you start the
 //  node it is silent and invisible to other nodes on the network.
 CZMQ_EXPORT zyre_t *
-    zyre_new (zctx_t *ctx);
+    zyre_new (void);
 
 //  Destructor, destroys a Zyre node. When you destroy a node, any
 //  messages it is sending or receiving will be discarded.
@@ -87,8 +87,8 @@ CZMQ_EXPORT int
 CZMQ_EXPORT int
     zyre_shouts (zyre_t *self, char *group, char *format, ...);
 
-//  Return handle to the Zyre node, for polling
-CZMQ_EXPORT void *
+//  Return socket for talking to the Zyre node, for polling
+CZMQ_EXPORT zsock_t *
     zyre_socket (zyre_t *self);
 
 //  Prints zyre information
@@ -139,10 +139,9 @@ EXAMPLE
 -------
 .From zyre_test method
 ----
-    zctx_t *ctx = zctx_new ();
     //  Create two nodes
-    zyre_t *node1 = zyre_new (ctx);
-    zyre_t *node2 = zyre_new (ctx);
+    zyre_t *node1 = zyre_new ();
+    zyre_t *node2 = zyre_new ();
     zyre_set_header (node1, "X-HELLO", "World");
     assert (strneq (zyre_uuid (node1), zyre_uuid (node2)));
 
@@ -151,8 +150,6 @@ EXAMPLE
     zyre_set_port (node1, 5670);
     zyre_set_port (node2, 5670);
     
-//     zyre_set_verbose (node1);
-//     zyre_set_verbose (node2);
     zyre_start (node1);
     zyre_start (node2);
     zyre_join (node1, "GLOBAL");
@@ -205,6 +202,5 @@ EXAMPLE
     
     zyre_destroy (&node1);
     zyre_destroy (&node2);
-    zctx_destroy (&ctx);
 ----
 

--- a/doc/zyre_log.txt
+++ b/doc/zyre_log.txt
@@ -10,7 +10,7 @@ SYNOPSIS
 ----
 //  Constructor
 CZMQ_EXPORT zyre_log_t *
-    zyre_log_new (zctx_t *ctx, const char *sender);
+    zyre_log_new (const char *sender);
 
 //  Destructor
 CZMQ_EXPORT void
@@ -47,15 +47,14 @@ EXAMPLE
 -------
 .From zyre_log_test method
 ----
-    zctx_t *ctx = zctx_new ();
     //  Get all incoming log messages
-    void *collector = zsocket_new (ctx, ZMQ_SUB);
-    zsocket_bind (collector, "tcp://127.0.0.1:5555");
-    zsocket_set_subscribe (collector, "");
+    zsock_t *collector = zsock_new (ZMQ_SUB);
+    zsock_bind (collector, "tcp://127.0.0.1:5550");
+    zsock_set_subscribe (collector, "");
 
     //  Create a log instance to send log messages
-    zyre_log_t *log = zyre_log_new (ctx, "this is me");
-    zyre_log_connect (log, "tcp://127.0.0.1:5555");
+    zyre_log_t *log = zyre_log_new ("this is me");
+    zyre_log_connect (log, "tcp://127.0.0.1:5550");
 
     //  Workaround for issue 270; give time for connect to
     //  happen and subscriptions to go to pub socket; 200
@@ -74,12 +73,12 @@ EXAMPLE
         zre_log_msg_t *msg = zre_log_msg_recv (collector);
         assert (msg);
         if (verbose)
-            zre_log_msg_dump (msg);
+            zre_log_msg_print (msg);
         zre_log_msg_destroy (&msg);
         count++;
     }
     zpoller_destroy (&poller);
     zyre_log_destroy (&log);
-    zctx_destroy (&ctx);
+    zsock_destroy (&collector);
 ----
 

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -89,8 +89,9 @@ CZMQ_EXPORT void
     zyre_set_interval (zyre_t *self, size_t interval);
 
 //  Start node, after setting header values. When you start a node it
-//  begins discovery and connection.
-CZMQ_EXPORT void
+//  begins discovery and connection. Returns 0 if OK, -1 if it wasn't
+//  possible to start the node.
+CZMQ_EXPORT int
     zyre_start (zyre_t *self);
 
 //  Stop node; this signals to other peers that this node will go away.

--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -215,14 +215,23 @@ zyre_event_test (bool verbose)
     //  @selftest
     //  Create two nodes
     zyre_t *node1 = zyre_new ();
-    zyre_t *node2 = zyre_new ();
+    assert (node1);
     zyre_set_header (node1, "X-HELLO", "World");
-    zyre_start (node1);
-    zyre_start (node2);
     zyre_set_verbose (node1);
-    zyre_set_verbose (node2);
+    if (zyre_start (node1)) {
+        zyre_destroy (&node1);
+        printf ("OK (skipping test, no UDP discovery)\n");
+        return;
+    }
     zyre_join (node1, "GLOBAL");
+    
+    zyre_t *node2 = zyre_new ();
+    assert (node2);
+    zyre_set_verbose (node2);
+    int rc = zyre_start (node2);
+    assert (rc == 0);
     zyre_join (node2, "GLOBAL");
+    
     //  Give time for them to interconnect
     zclock_sleep (250);
 


### PR DESCRIPTION
Following #714d80 in CZMQ, it's now possible to detect when the
current system does not support beacons. Now we need to know at
the Zyre app level if beaconing is broken.

Solution: expand zyre_start() to return a status code, 0 if OK,
-1 if beaconing is broken. We use this in the selftests to skip
if the system looks broken.

Test case is a laptop with WiFi switched off, and no ethernet, as
the loopback interface does not do UDP broadcasts and thus cannot
work for beaconing.
