### PR TITLE
Problem: 'interface' is reserved on C++

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -103,7 +103,7 @@ CZMQ_EXPORT void
 //  with multiple interfaces you really should specify which one you
 //  want to use, or strange things can happen.
 CZMQ_EXPORT void
-    zyre_set_interface (zyre_t *self, const char *interface);
+    zyre_set_interface (zyre_t *self, const char *value);
 
 //  Start node, after setting header values. When you start a node it
 //  begins discovery and connection. Returns 0 if OK, -1 if it wasn't

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -234,10 +234,10 @@ zyre_set_interval (zyre_t *self, size_t interval)
 //  want to use, or strange things can happen.
 
 void
-zyre_set_interface (zyre_t *self, const char *interface)
+zyre_set_interface (zyre_t *self, const char *value)
 {
     //  Implemented by zsys global for now
-    zsys_set_interface (interface);
+    zsys_set_interface (value);
 }
 
 


### PR DESCRIPTION
On MSVC we use C++ to compile, so this variable name breaks things.
Solution: use a different variable name.
