### PR TITLE
Problem: allow Zyre to work across any transport

### DIFF
--- a/include/zre_log_msg.h
+++ b/include/zre_log_msg.h
@@ -193,6 +193,9 @@ CZMQ_EXPORT int
     zre_log_msg_test (bool verbose);
 //  @end
 
+//  For backwards compatibility with old codecs
+#define zre_log_msg_dump    zre_log_msg_print
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zre_msg.h
+++ b/include/zre_msg.h
@@ -40,8 +40,7 @@
 
     HELLO - Greet a peer so it can connect back to us
         sequence            number 2    Incremental sequence number
-        ipaddress           string      Sender IP address
-        mailbox             number 2    Sender mailbox port numer
+        endpoint            string      Sender connect endpoint
         groups              strings     List of groups sender is in
         status              number 1    Sender groups status sequence
         name                string      Sender public name
@@ -135,8 +134,7 @@ CZMQ_EXPORT int
 CZMQ_EXPORT zmsg_t *
     zre_msg_encode_hello (
         uint16_t sequence,
-        const char *ipaddress,
-        uint16_t mailbox,
+        const char *endpoint,
         zlist_t *groups,
         byte status,
         const char *name,
@@ -185,8 +183,7 @@ CZMQ_EXPORT zmsg_t *
 CZMQ_EXPORT int
     zre_msg_send_hello (void *output,
         uint16_t sequence,
-        const char *ipaddress,
-        uint16_t mailbox,
+        const char *endpoint,
         zlist_t *groups,
         byte status,
         const char *name,
@@ -263,17 +260,11 @@ CZMQ_EXPORT uint16_t
 CZMQ_EXPORT void
     zre_msg_set_sequence (zre_msg_t *self, uint16_t sequence);
 
-//  Get/set the ipaddress field
+//  Get/set the endpoint field
 CZMQ_EXPORT const char *
-    zre_msg_ipaddress (zre_msg_t *self);
+    zre_msg_endpoint (zre_msg_t *self);
 CZMQ_EXPORT void
-    zre_msg_set_ipaddress (zre_msg_t *self, const char *format, ...);
-
-//  Get/set the mailbox field
-CZMQ_EXPORT uint16_t
-    zre_msg_mailbox (zre_msg_t *self);
-CZMQ_EXPORT void
-    zre_msg_set_mailbox (zre_msg_t *self, uint16_t mailbox);
+    zre_msg_set_endpoint (zre_msg_t *self, const char *format, ...);
 
 //  Get/set the groups field
 CZMQ_EXPORT zlist_t *
@@ -350,6 +341,9 @@ CZMQ_EXPORT void
 CZMQ_EXPORT int
     zre_msg_test (bool verbose);
 //  @end
+
+//  For backwards compatibility with old codecs
+#define zre_msg_dump        zre_msg_print
 
 #ifdef __cplusplus
 }

--- a/src/zre_log_msg.c
+++ b/src/zre_log_msg.c
@@ -377,7 +377,7 @@ zre_log_msg_recv (void *input)
         if (!routing_id || !zmsg_next (msg))
             return NULL;        //  Malformed or empty
     }
-    zre_log_msg_t * zre_log_msg = zre_log_msg_decode (&msg);
+    zre_log_msg_t *zre_log_msg = zre_log_msg_decode (&msg);
     if (zsocket_type (zsock_resolve (input)) == ZMQ_ROUTER)
         zre_log_msg->routing_id = routing_id;
 
@@ -402,7 +402,7 @@ zre_log_msg_recv_nowait (void *input)
         if (!routing_id || !zmsg_next (msg))
             return NULL;        //  Malformed or empty
     }
-    zre_log_msg_t * zre_log_msg = zre_log_msg_decode (&msg);
+    zre_log_msg_t *zre_log_msg = zre_log_msg_decode (&msg);
     if (zsocket_type (zsock_resolve (input)) == ZMQ_ROUTER)
         zre_log_msg->routing_id = routing_id;
 

--- a/src/zre_msg.bnf
+++ b/src/zre_msg.bnf
@@ -1,16 +1,14 @@
 The following ABNF grammar defines the work with ZRE messages:
 
-    ZRE             = N:greeting *traffic
-    greeting        = N:hello
-    traffic         = N:whisper / N:shout / N:join / N:leave
-                    / N:ping P:ping-ok
+    zre             = greeting *traffic
+    greeting        = hello
+    traffic         = whisper / shout / join / leave / ping / ping-ok
 
     ;     Greet a peer so it can connect back to us
-    hello           = signature %d1 sequence ipaddress mailbox groups status name headers
+    hello           = signature %d1 sequence endpoint groups status name headers
     signature       = %xAA %xA1             ; two octets
     sequence        = number-2              ; Incremental sequence number
-    ipaddress       = string                ; Sender IP address
-    mailbox         = number-2              ; Sender mailbox port numer
+    endpoint        = string                ; Sender connect endpoint
     groups          = strings               ; List of groups sender is in
     status          = number-1              ; Sender groups status sequence
     name            = string                ; Sender public name

--- a/src/zre_msg.xml
+++ b/src/zre_msg.xml
@@ -5,15 +5,14 @@
     script = "zproto_codec_c"
     header = "../include"
     >
-    This is the ZRE protocol raw version.
-    
+    This is the ZRE protocol, version 2 draft, as defined by rfc.zeromq.org/spec:36/ZRE.
+
     <include filename = "license.xml" />
 
     <grammar>
-    ZRE             = N:greeting *traffic
-    greeting        = N:hello
-    traffic         = N:whisper / N:shout / N:join / N:leave
-                    / N:ping P:ping-ok
+    zre             = greeting *traffic
+    greeting        = hello
+    traffic         = whisper / shout / join / leave / ping / ping-ok
     </grammar>
 
     <!-- Protocol constants -->
@@ -25,8 +24,8 @@
     </header>
 
     <message name = "HELLO" id = "1">
-        <field name = "ipaddress" type = "string">Sender IP address</field>
-        <field name = "mailbox" type = "number" size = "2">Sender mailbox port numer</field>
+        <!-- endpoint includes transport, etc. "tcp://127.0.0.1:2225" -->
+        <field name = "endpoint" type = "string">Sender connect endpoint</field>
         <field name = "groups" type = "strings">List of groups sender is in</field>
         <field name = "status" type = "number" size = "1">Sender groups status sequence</field>
         <field name = "name" type = "string">Sender public name</field>

--- a/src/zyre_group.c
+++ b/src/zyre_group.c
@@ -153,7 +153,7 @@ zyre_group_test (bool verbose)
     zyre_group_join (group, peer);
     
     zre_msg_t *msg = zre_msg_new (ZRE_MSG_HELLO);
-    zre_msg_set_ipaddress (msg, "127.0.0.1");
+    zre_msg_set_endpoint (msg, "tcp://127.0.0.1:5552");
     zyre_group_send (group, &msg);
 
     msg = zre_msg_recv (mailbox);

--- a/src/zyre_peer.c
+++ b/src/zyre_peer.c
@@ -423,7 +423,7 @@ zyre_peer_test (bool verbose)
     assert (streq (zyre_peer_name (peer), "peer"));
 
     zre_msg_t *msg = zre_msg_new (ZRE_MSG_HELLO);
-    zre_msg_set_ipaddress (msg, "127.0.0.1");
+    zre_msg_set_endpoint (msg, "tcp://127.0.0.1:5552");
     int rc = zyre_peer_send (peer, &msg);
     assert (rc == 0);
 


### PR DESCRIPTION
This is the first of a series of commits to expand Zyre for (a) other transports and (b) other discovery methods.
- Added explicit bind/connect methods to API so application can build
  the cluster explicitly, using any available ZeroMQ transport.
- Application can now switch off UDP discovery by setting port to 0.
- Replaced ipaddress / port fields with endpoint so that nodes can
  now interconnect across any ZeroMQ transport.
