### PR TITLE
Set ZMQ_ROUTER_HANDOVER on node inbox

### DIFF
--- a/src/zyre_peer.c
+++ b/src/zyre_peer.c
@@ -173,15 +173,14 @@ zyre_peer_send (zyre_peer_t *self, zre_msg_t **msg_p)
             zyre_log_info (self->log, ZRE_LOG_MSG_EVENT_SEND,
                 zuuid_str (self->uuid), "seq=%d command=%s",
                 zre_msg_sequence (*msg_p), zre_msg_command (*msg_p));
-        int rc = zre_msg_send (msg_p, self->mailbox);
-        if (rc == -1) {
+            
+        if (zre_msg_send (msg_p, self->mailbox)) {
             if (errno == EAGAIN) {
                 zyre_peer_disconnect (self);
                 return -1;
             }
-            else
-                //  Can't get any other error here
-                assert (false);
+            //  Can't get any other error here
+            assert (false);
         }
     }
     else


### PR DESCRIPTION
Problem: was incorrectly taking old PING messages from disconnected
peer socket, and ignoring new HELLO commands. The previous fix was
to destroy the peer and retry. However that didn't address the real
problem.

Solution: set ZMQ_ROUTER_HANDOVER on the router socket, so that new
client connections always replace existing ones.

This appears to work properly; the test is to run several instances
of zpinger on a laptop connected to a WiFi network, then disable the
WiFi interface, and then re-enable it. zpinger should first report
that its peers have exited, and then that they reappear.

Fixes #200 (properly, this time).
