### PR TITLE
Windows strdup replacement did not correctly initialise memory

### DIFF
--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -103,6 +103,7 @@ zyre_node_new (zsock_t *pipe, void *args)
     //  Default name for node is first 6 characters of UUID:
     //  the shorter string is more readable in logs
     self->name = (char*)malloc(7);
+    memset(self->name, 0, 7);
     strncpy (self->name, zuuid_str (self->uuid), 6);
 
     return self;


### PR DESCRIPTION
No known side-effects, but bad
