### PR TITLE
Further work on Zyre gossip discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,8 @@ testit
 *.pc
 zpinger
 zlogger
-ztester
+ztester_beacon
+ztester_gossip
 perf_local
 perf_remote
 zyre_selftest
@@ -42,11 +43,6 @@ src/test-suite.log
 src/zyre_selftest.log
 src/zyre_selftest.trs
 
-src/zyre_logger
-src/zyre_perf_local
-src/zyre_perf_remote
-src/zyre_ping
-src/zyre_tester
 CMakeCache.txt
 CMakeFiles/
 CTestTestfile.cmake

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -77,13 +77,17 @@ ZYRE_EXPORT zyre_t *
 ZYRE_EXPORT void
     zyre_destroy (zyre_t **self_p);
 
-//  Return our node UUID, after successful initialization
+//  Return our node UUID string, after successful initialization
 ZYRE_EXPORT const char *
     zyre_uuid (zyre_t *self);
 
 //  Return our node name, after successful initialization
 ZYRE_EXPORT const char *
     zyre_name (zyre_t *self);
+
+//  Return our endpoint, after successful bind to endpoint
+ZYRE_EXPORT const char *
+    zyre_endpoint (zyre_t *self);
 
 //  Set node header; these are provided to other nodes during discovery
 //  and come in each ENTER message.
@@ -119,7 +123,7 @@ ZYRE_EXPORT void
 //  Zyre nodes in the cluster (i.e. do not mix inproc and TCP). Do not call
 //  this method more than once.
 ZYRE_EXPORT void
-    zyre_set_endpoint (zyre_t *self, const char *endpoint);
+    zyre_set_endpoint (zyre_t *self, const char *format, ...);
 
 //  Set-up gossip discovery of other nodes. At least one node in the cluster
 //  must bind to a well-known gossip endpoint, so other nodes can connect to
@@ -195,6 +199,12 @@ ZYRE_EXPORT void
 ZYRE_EXPORT void
     zyre_test (bool verbose);
 //  @end
+
+//  Compiler hints
+ZYRE_EXPORT void zyre_set_header (zyre_t *self, const char *name, const char *format, ...) CHECK_PRINTF (3);
+ZYRE_EXPORT void zyre_set_endpoint (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
+ZYRE_EXPORT int zyre_whispers (zyre_t *self, const char *peer, const char *format, ...) CHECK_PRINTF (3);
+ZYRE_EXPORT int zyre_shouts (zyre_t *self, const char *group, const char *format, ...) CHECK_PRINTF (3);
 
 #ifdef __cplusplus
 }

--- a/src/zyre_peer.c
+++ b/src/zyre_peer.c
@@ -72,7 +72,8 @@ zyre_peer_new (zhash_t *container, zuuid_t *uuid)
 
     //  Insert into container if requested
     if (container) {
-        zhash_insert (container, zuuid_str (self->uuid), self);
+        int rc = zhash_insert (container, zuuid_str (self->uuid), self);
+        assert (rc == 0);
         zhash_freefn (container, zuuid_str (self->uuid), s_delete_peer);
     }
     return self;

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,20 +1,25 @@
 EXTRA_DIST = zpinger.c \
-             ztester.c \
+             ztester_beacon.c \
+             ztester_gossip.c \
              perf_local.c \
              perf_remote.c
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
 
 bin_PROGRAMS = zpinger \
-               ztester \
+               ztester_beacon \
+               ztester_gossip \
                perf_local \
                perf_remote
 
 zpinger_LDADD = $(top_builddir)/src/libzyre.la
 zpinger_SOURCES = zpinger.c
 
-ztester_LDADD = $(top_builddir)/src/libzyre.la
-ztester_SOURCES = ztester.c
+ztester_beacon_LDADD = $(top_builddir)/src/libzyre.la
+ztester_beacon_SOURCES = ztester_beacon.c
+
+ztester_gossip_LDADD = $(top_builddir)/src/libzyre.la
+ztester_gossip_SOURCES = ztester_gossip.c
 
 perf_local_LDADD = $(top_builddir)/src/libzyre.la
 perf_local_SOURCES = perf_local.c

--- a/tools/perf_remote.c
+++ b/tools/perf_remote.c
@@ -105,12 +105,12 @@ node_actor (zsock_t *pipe, void *args)
 
         //  Send outgoing messages if needed
         if (to_peer) {
-            zyre_whispers (node, to_peer, sending_cookie);
+            zyre_whispers (node, to_peer, "%s", sending_cookie);
             free (to_peer);
             to_peer = NULL;
         }
         if (to_group) {
-            zyre_shouts (node, to_group, sending_cookie);
+            zyre_shouts (node, to_group, "%s", sending_cookie);
             free (to_group);
             to_group = NULL;
         }

--- a/tools/ztester_beacon.c
+++ b/tools/ztester_beacon.c
@@ -1,0 +1,199 @@
+/*  =========================================================================
+    ztester_beacon - bulk test tool using UDP beacon discovery
+
+    This tool starts many nodes, each as a thread (zactor), which discover
+    each other using UDP beacons (zbeacon) and interconnect over TCP.
+    
+    -------------------------------------------------------------------------
+    Copyright (c) 1991-2012 iMatix Corporation <www.imatix.com>
+    Copyright other contributors as noted in the AUTHORS file.
+
+    This file is part of Zyre, an open-source framework for proximity-based
+    peer-to-peer applications -- See http://zyre.org.
+
+    This is free software; you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation; either version 3 of the License, or (at
+    your option) any later version.
+
+    This software is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this program. If not, see
+    <http://www.gnu.org/licenses/>.
+    =========================================================================
+*/
+
+#include "../include/zyre.h"
+
+#define MAX_GROUP 10
+
+static void
+node_actor (zsock_t *pipe, void *args)
+{
+    zyre_t *node = zyre_new (NULL);
+    if (!node)
+        return;                 //  Could not create new node
+    zyre_set_verbose (node);
+    zyre_start (node);
+    zsock_signal (pipe, 0);     //  Signal "ready" to caller
+
+    int64_t counter = 0;
+    char *to_peer = NULL;       //  Either of these set,
+    char *to_group = NULL;      //    and we set a message
+    char *cookie = NULL;
+
+    zpoller_t *poller = zpoller_new (pipe, zyre_socket (node), NULL);
+    int64_t trigger = zclock_time () + 1000;
+    while (!zsys_interrupted) {
+        void *which = zpoller_wait (poller, randof (1000));
+        if (!which)
+            break;              //  Interrupted
+
+        //  $TERM from parent means exit; anything else is breach of
+        //  contract so we should assert
+        if (which == pipe) {
+            char *command = zstr_recv (pipe);
+            assert (streq (command, "$TERM"));
+            zstr_free (&command);
+            break;              //  Finished
+        }
+        //  Process an event from node
+        if (which == zyre_socket (node)) {
+            zmsg_t *incoming = zyre_recv (node);
+            if (!incoming)
+                break;          //  Interrupted
+
+            char *event = zmsg_popstr (incoming);
+            char *peer = zmsg_popstr (incoming);
+            char *name = zmsg_popstr (incoming);
+            if (streq (event, "ENTER"))
+                //  Always say hello to new peer
+                to_peer = peer;
+            else
+            if (streq (event, "EXIT"))
+                //  Always try talk to departed peer
+                to_peer = peer;
+            else
+            if (streq (event, "WHISPER")) {
+                //  Send back response 1/2 the time
+                if (randof (2) == 0) {
+                    to_peer = peer;
+                    cookie = zmsg_popstr (incoming);
+                }
+            }
+            else
+            if (streq (event, "SHOUT")) {
+                to_peer = peer;
+                to_group = zmsg_popstr (incoming);
+                cookie = zmsg_popstr (incoming);
+                //  Send peer response 1/3rd the time
+                if (randof (3) > 0) {
+                    free (to_peer);
+                    to_peer = NULL;
+                }
+                //  Send group response 1/3rd the time
+                if (randof (3) > 0) {
+                    free (to_group);
+                    to_group = NULL;
+                }
+            }
+            else
+            if (streq (event, "JOIN")) {
+                char *group = zmsg_popstr (incoming);
+                printf ("I: %s joined %s\n", name, group);
+                free (group);
+            }
+            else
+            if (streq (event, "LEAVE")) {
+                char *group = zmsg_popstr (incoming);
+                printf ("I: %s left %s\n", name, group);
+                free (group);
+            }
+            free (event);
+            free (peer);
+            free (name);
+            zmsg_destroy (&incoming);
+
+            //  Send outgoing messages if needed
+            if (to_peer) {
+                zyre_whispers (node, to_peer, "%lu", counter++);
+                free (to_peer);
+                to_peer = NULL;
+            }
+            if (to_group) {
+                zyre_shouts (node, to_group, "%lu", counter++);
+                free (to_group);
+                to_group = NULL;
+            }
+            if (cookie) {
+                free (cookie);
+                cookie = NULL;
+            }
+        }
+        if (zclock_time () >= trigger) {
+            trigger = zclock_time () + 1000;
+            char group [10];
+            sprintf (group, "GROUP%03d", randof (MAX_GROUP));
+            if (randof (4) == 0)
+                zyre_join (node, group);
+            else
+            if (randof (3) == 0)
+                zyre_leave (node, group);
+        }
+    }
+    zpoller_destroy (&poller);
+    zyre_destroy (&node);
+}
+
+
+int main (int argc, char *argv [])
+{
+    //  Get number of nodes N to simulate
+    //  We need 3 x N x N + 3N file handles
+    int max_nodes = 10;
+    int nbr_nodes = 0;
+    if (argc > 1)
+        max_nodes = atoi (argv [1]);
+
+    int max_iterations = -1;
+    int nbr_iterations = 0;
+    if (argc > 2)
+        max_iterations = atoi (argv [2]);
+
+    //  We address nodes as an array of actors
+    zactor_t **actors = zmalloc (sizeof (zactor_t *) * max_nodes);
+
+    //  We will randomly start and stop node threads
+    uint index;
+    while (!zsys_interrupted) {
+        index = randof (max_nodes);
+        //  Toggle node thread
+        if (actors [index]) {
+            zactor_destroy (&actors [index]);
+            actors [index] = NULL;
+            zclock_log ("I: Stopped node (%d running)", --nbr_nodes);
+        }
+        else {
+            actors [index] = zactor_new (node_actor, NULL);
+            zclock_log ("I: Started node (%d running)", ++nbr_nodes);
+        }
+        nbr_iterations++;
+        if (max_iterations > 0 && nbr_iterations >= max_iterations)
+            break;
+        //  Sleep ~750 msecs randomly so we smooth out activity
+        zclock_sleep (randof (500) + 500);
+    }
+    zclock_log ("I: Stopped tester (%d iterations)", nbr_iterations);
+
+    //  Stop all remaining actors
+    for (index = 0; index < max_nodes; index++) {
+        if (actors [index])
+            zactor_destroy (&actors [index]);
+    }
+    free (actors);
+    return 0;
+}


### PR DESCRIPTION
Added tools/ztester_gossip, which stress tests this structure.
Right now it's failing due to rapid socket disconnect/reconnect
with "lost messages" errors and an assertion in libzmq/src/fq.cpp.
