### PR TITLE
Fix formats passed in ztester tools

### DIFF
--- a/tools/ztester_beacon.c
+++ b/tools/ztester_beacon.c
@@ -120,12 +120,12 @@ node_actor (zsock_t *pipe, void *args)
 
             //  Send outgoing messages if needed
             if (to_peer) {
-                zyre_whispers (node, to_peer, "%lu", counter++);
+                zyre_whispers (node, to_peer, "%lld", counter++);
                 free (to_peer);
                 to_peer = NULL;
             }
             if (to_group) {
-                zyre_shouts (node, to_group, "%lu", counter++);
+                zyre_shouts (node, to_group, "%lld", counter++);
                 free (to_group);
                 to_group = NULL;
             }

--- a/tools/ztester_gossip.c
+++ b/tools/ztester_gossip.c
@@ -126,12 +126,12 @@ node_actor (zsock_t *pipe, void *args)
 
             //  Send outgoing messages if needed
             if (to_peer) {
-                zyre_whispers (node, to_peer, "%lu", counter++);
+                zyre_whispers (node, to_peer, "%lld", counter++);
                 free (to_peer);
                 to_peer = NULL;
             }
             if (to_group) {
-                zyre_shouts (node, to_group, "%lu", counter++);
+                zyre_shouts (node, to_group, "%lld", counter++);
                 free (to_group);
                 to_group = NULL;
             }


### PR DESCRIPTION
Caused format specification errors under clang on MacOS:
argument has type 'int64_t' (aka 'long long') [-Werror,-Wformat]
