### PR TITLE
Rewrote chat example using zactor instead of zthread

### DIFF
--- a/examples/chat/chat.c
+++ b/examples/chat/chat.c
@@ -26,46 +26,76 @@
 
 #include "zyre.h"
 
-//  This thread will listen and publish anything received
+//  This actor will listen and publish anything received
 //  on the CHAT group
 
-static void
-chat_task (void *args, zctx_t *ctx, void *pipe)
+static void 
+chat_actor (zsock_t *pipe, void *args)
 {
-    zyre_t *node = zyre_new ("chat");
+    //  Do some initialization
+    char*   name = (char*) args;
+    zyre_t *node = zyre_new (name);
+    if (!node)
+        return;                 //  Could not create new node
+    //zyre_set_verbose (node);  // uncomment to watch the events
     zyre_start (node);
     zyre_join (node, "CHAT");
+    zsock_signal (pipe, 0);     //  Signal "ready" to caller
 
-    zmq_pollitem_t items [] = {
-        { pipe, 0, ZMQ_POLLIN, 0 },
-        { zyre_socket (node), 0, ZMQ_POLLIN, 0 }
-    };
-    while (true) {
-        if (zmq_poll (items, 2, -1) == -1)
-            break;              //  Interrupted
-
-        //  Activity on my pipe
-        if (items [0].revents & ZMQ_POLLIN) {
-            zmsg_t *msg = zmsg_recv (pipe);
-            zyre_shout (node, "CHAT", &msg);
-        }
-        //  Activity on my node handle
-        if (items [1].revents & ZMQ_POLLIN) {
-            zmsg_t *msg = zyre_recv (node);
-            zmsg_dump (msg);
+    bool terminated = false;
+    zpoller_t *poller = zpoller_new (pipe, zyre_socket (node), NULL);
+    while (!terminated) {
+        void *which = zpoller_wait (poller, -1); // no timeout
+        if (which == pipe){
+            zmsg_t *msg = zmsg_recv (which);
+            if (!msg)
+                break;              //  Interrupted
             char *command = zmsg_popstr (msg);
-            if (streq (command, "SHOUT")) {
-                //  Discard sender and group name
-                free (zmsg_popstr (msg));
-                free (zmsg_popstr (msg));
-                char *message = zmsg_popstr (msg);
-                printf ("%s", message);
-                free (message);
+            if (streq (command, "$TERM")) {
+                terminated = true;
+            }
+            else
+            if (streq (command, "SHOUT")) { 
+                char *string = zmsg_popstr (msg);
+                zyre_shouts (node, "CHAT", "%s", string);
+            }
+            else {
+                puts ("E: invalid message to actor");
+                assert (false);
             }
             free (command);
             zmsg_destroy (&msg);
         }
+        else if (which == zyre_socket (node)) {
+            zmsg_t *msg = zmsg_recv (which);
+            char *event = zmsg_popstr (msg);
+            char *peer = zmsg_popstr (msg);
+            char *name = zmsg_popstr (msg);
+            char *group = zmsg_popstr (msg);
+            char *message = zmsg_popstr (msg);
+
+            if (streq (event, "ENTER")) { 
+                printf ("%s has joined the chat\n", name);
+            }
+            else if (streq (event, "EXIT")) { 
+                printf ("%s has left the chat\n", name);
+            }
+            if (streq (event, "SHOUT")) { 
+                printf ("%s: %s\n", name, message);
+            }
+            //printf ("Message from node\n");
+            //printf ("event: %s peer: %s  name: %s\n  group: %s message: %s\n", event, peer, name, group, message);
+
+            free (event);
+            free (peer);
+            free (name);
+            free (group);
+            free (message);
+            zmsg_destroy (&msg);
+        }
     }
+    zpoller_destroy (&poller);
+
     // Notify peers that this peer is shutting down. Provide
     // a brief interval to ensure message is emitted.
     zyre_stop(node);
@@ -74,20 +104,29 @@ chat_task (void *args, zctx_t *ctx, void *pipe)
     zyre_destroy (&node);
 }
 
-int main (int argn, char *argv [])
+
+
+int
+main (int argc, char *argv[])
 {
-    if (argn < 2) {
-        puts ("syntax: ./zyrechat myname");
+    if (argc < 2) {
+        puts ("syntax: ./chat myname");
         exit (0);
     }
-    zctx_t *ctx = zctx_new ();
-    void *chat_pipe = zthread_fork (ctx, chat_task, NULL);
-    while (!zctx_interrupted) {
+    zactor_t *actor = zactor_new (chat_actor, argv[1]);
+    assert (actor);
+    
+    while (!zsys_interrupted) {
         char message [1024];
-        if (!fgets (message, 1024, stdin))
-            break;
-        zstr_sendf (chat_pipe, "%s:%s", argv [1], message);
+        if (!fgets( message, 1024, stdin))
+	        break;
+	    message[strlen(message)-1] = 0; // drop the trailing linefeed
+	    zstr_sendx (actor, "SHOUT", message, NULL);
     }
-    zctx_destroy (&ctx);
+
+    zactor_destroy (&actor);
+
     return 0;
 }
+
+


### PR DESCRIPTION
The chat example wasn't working as-is.  Digging it, it seemed zactor is intended for everyday use over zthread, so I rewrote chat using actor instead of threads.  It should behave more or less the same as the previous example was intended.
