### PR TITLE
zyre_peers - return a zlist, not a zhash, for safety

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -181,9 +181,9 @@ ZYRE_EXPORT int
 ZYRE_EXPORT int
     zyre_shouts (zyre_t *self, const char *group, const char *format, ...);
 
-//  Return zhash of current peers. The caller owns this hash and should
+//  Return zlist of current peer ids. The caller owns this list and should
 //  destroy it when finished with it.
-ZYRE_EXPORT zhash_t *
+ZYRE_EXPORT zlist_t *
     zyre_peers (zyre_t *self);
 
 //  Return socket for talking to the Zyre node, for polling

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -456,15 +456,15 @@ zyre_shouts (zyre_t *self, const char *group, const char *format, ...)
 
 
 //  --------------------------------------------------------------------------
-//  Return zhash of current peers. The caller owns this hash and should
+//  Return zlist of current peers. The caller owns this list and should
 //  destroy it when finished with it.
 
-zhash_t *
+zlist_t *
 zyre_peers (zyre_t *self)
 {
-    zhash_t *peers;
+    zlist_t *peers;
     zstr_send (self->actor, "PEERS");
-    zsock_recv (self->actor, "h", &peers);
+    zsock_recv (self->actor, "p", &peers);
     return peers;
 }
 
@@ -564,10 +564,10 @@ zyre_test (bool verbose)
     if (verbose)
         zyre_dump (node1);
 
-    zhash_t *peers = zyre_peers (node1);
+    zlist_t *peers = zyre_peers (node1);
     assert (peers);
-    assert (zhash_size (peers) == 1);
-    zhash_destroy (&peers);
+    assert (zlist_size (peers) == 1);
+    zlist_destroy (&peers);
 
     //  One node shouts to GLOBAL
     zyre_shouts (node1, "GLOBAL", "Hello, World");

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -437,7 +437,7 @@ zyre_node_recv_api (zyre_node_t *self)
     }
     else
     if (streq (command, "PEERS"))
-        zsock_send (self->pipe, "h", self->peers);
+        zsock_send (self->pipe, "p", zhash_keys (self->peers));
     else
     if (streq (command, "DUMP"))
         zyre_node_dump (self);


### PR DESCRIPTION
Specifically, if the user is tempted to access the elements in the returned hash (as I was) then they will open themselves to unpleasant race conditions with the node actor. Simply returning the peer ids in a list makes it impossible for this to occur.
