### PR TITLE
zyre_peer_connect takes const string, not mutable

### DIFF
--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -481,7 +481,7 @@ zyre_node_require_peer (zyre_node_t *self, zuuid_t *uuid, const char *endpoint)
         assert (peer);
         zyre_peer_set_origin (peer, self->name);
         zyre_peer_set_verbose (peer, self->verbose);
-        zyre_peer_connect (peer, self->uuid, (char *) endpoint);
+        zyre_peer_connect (peer, self->uuid, endpoint);
 
         //  Handshake discovery by sending HELLO as first message
         zlist_t *groups = zhash_keys (self->own_groups);

--- a/src/zyre_peer.c
+++ b/src/zyre_peer.c
@@ -105,7 +105,7 @@ zyre_peer_destroy (zyre_peer_t **self_p)
 //  Configures mailbox and connects to peer's router endpoint
 
 void
-zyre_peer_connect (zyre_peer_t *self, zuuid_t *from, char *endpoint)
+zyre_peer_connect (zyre_peer_t *self, zuuid_t *from, const char *endpoint)
 {
     assert (self);
     assert (!self->connected);

--- a/src/zyre_peer.h
+++ b/src/zyre_peer.h
@@ -43,7 +43,7 @@ void
 
 //  Connect peer mailbox
 void
-    zyre_peer_connect (zyre_peer_t *self, zuuid_t *from, char *endpoint);
+    zyre_peer_connect (zyre_peer_t *self, zuuid_t *from, const char *endpoint);
 
 //  Connect peer mailbox
 void


### PR DESCRIPTION
minor thing, but the cast confused me for a moment.
