### PR TITLE
zyre_new uses its address instead of generating random ids.

### DIFF
--- a/src/zyre.c
+++ b/src/zyre.c
@@ -89,17 +89,17 @@ zyre_new (const char *name)
     //  Create front-to-back pipe pair for data traffic
     self->inbox = zsock_new (ZMQ_PAIR);
     assert (self->inbox);
-    char endpoint [32];
-    while (true) {
-        sprintf (endpoint, "inproc://zyre-%04x-%04x\n",
-                 randof (0x10000), randof (0x10000));
-        if (zsock_bind (self->inbox, "%s", endpoint) == 0)
-            break;
-    }
+
+    // Use the unique address of the node to identify the inproc endpoint.
+    char endpoint [40];
+    sprintf (endpoint, "inproc://zyre-%p\n", self);
+    int errcode = zsock_bind (self->inbox, "%s", endpoint);
+    assert (errcode == 0);
+
     //  Create other half of traffic pipe
     zsock_t *outbox = zsock_new_pair (endpoint);
     assert (outbox);
-    
+
     //  Start node engine and wait for it to be ready
     self->actor = zactor_new (zyre_node_actor, outbox);
     assert (self->actor);


### PR DESCRIPTION
It shows a closer correspondence with the originating node, which is potentially useful when debugging. Also stops any possibility of generating collisions, removing the need for the loop and any possibility of a hang resulting from the inability to bind an inproc socket for some reason other than name clash. Generally makes the code simpler.
