### PR TITLE
Problem: After the first ENTER message, we can't get a peer's address 

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -186,6 +186,11 @@ ZYRE_EXPORT int
 ZYRE_EXPORT zlist_t *
     zyre_peers (zyre_t *self);
 
+//  Return the endpoint of a connected peer. Caller owns the
+//  string.
+ZYRE_EXPORT char *
+	zyre_peer_address(zyre_t *self, const char *peer);
+
 //  Return socket for talking to the Zyre node, for polling
 ZYRE_EXPORT zsock_t *
     zyre_socket (zyre_t *self);

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -439,6 +439,14 @@ zyre_node_recv_api (zyre_node_t *self)
     if (streq (command, "PEERS"))
         zsock_send (self->pipe, "p", zhash_keys (self->peers));
     else
+	if (streq (command, "PEER ENDPOINT")) {
+		char *uuid = zmsg_popstr (request);
+		zyre_peer_t *peer = (zyre_peer_t *) zhash_lookup (self->peers, (void *) uuid);
+		assert (peer);
+		zsock_send (self->pipe, "s", zyre_peer_endpoint (peer));
+		zstr_free (&uuid);
+	}
+	else
     if (streq (command, "DUMP"))
         zyre_node_dump (self);
     else


### PR DESCRIPTION
Problem: After the first ENTER message, we can't get a peer's address (endpoint).

Solution: A getter method for a peer's address.
