### PR TITLE
Add ability to enumerate currently active groups

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -186,6 +186,16 @@ ZYRE_EXPORT int
 ZYRE_EXPORT zlist_t *
     zyre_peers (zyre_t *self);
 
+//  Return zlist of currently joined groups. The caller owns this list and
+//  should destroy it when finished with it.
+ZYRE_EXPORT zlist_t *
+    zyre_own_groups (zyre_t *self);
+
+//  Return zlist of groups known through connected peers. The caller owns this
+//  list and should destroy it when finished with it.
+ZYRE_EXPORT zlist_t *
+    zyre_peer_groups (zyre_t *self);
+
 //  Return socket for talking to the Zyre node, for polling
 ZYRE_EXPORT zsock_t *
     zyre_socket (zyre_t *self);

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -439,6 +439,12 @@ zyre_node_recv_api (zyre_node_t *self)
     if (streq (command, "PEERS"))
         zsock_send (self->pipe, "p", zhash_keys (self->peers));
     else
+    if (streq (command, "PEER GROUPS"))
+        zsock_send (self->pipe, "p", zhash_keys (self->peer_groups));
+    else
+    if (streq (command, "OWN GROUPS"))
+        zsock_send (self->pipe, "p", zhash_keys (self->own_groups));
+    else
     if (streq (command, "DUMP"))
         zyre_node_dump (self);
     else


### PR DESCRIPTION
Applications using zyre should not need to do bookkeeping for information which is available within zyre directly.
