### PR TITLE
Problem: Can't retrieve peer header information after first ENTER message

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -201,6 +201,12 @@ ZYRE_EXPORT zlist_t *
 ZYRE_EXPORT char *
     zyre_peer_address(zyre_t *self, const char *peer);
 
+//  Return the value of a header of a conected peer. 
+//  Returns null if peer or key doesn't exits. Caller
+//  owns the string
+ZYRE_EXPORT char *
+    zyre_peer_header_value (zyre_t *self, const char *peer, const char *name);
+
 //  Return socket for talking to the Zyre node, for polling
 ZYRE_EXPORT zsock_t *
     zyre_socket (zyre_t *self);

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -483,6 +483,23 @@ zyre_peer_address(zyre_t *self, const char *peer)
     return address;
 }
 
+//  --------------------------------------------------------------------------
+//  Return the value of a header of a conected peer. 
+//  Returns null if peer or key doesn't exits. Caller
+//  owns the string
+char *
+zyre_peer_header_value (zyre_t *self, const char *peer, const char *name)
+{
+    assert (self);
+    assert (peer);
+    assert (name);
+    char *value;
+    zstr_sendm (self->actor, "PEER HEADER");
+    zstr_sendm (self->actor, peer);
+    zstr_send (self->actor, name);
+    value = zstr_recv (self->actor);
+    return value;
+}
 
 //  --------------------------------------------------------------------------
 //  Return zlist of currently joined groups. The caller owns this list and
@@ -641,6 +658,10 @@ zyre_test (bool verbose)
         }
     }
     zlist_destroy(&peer_groups);
+
+    char *value = zyre_peer_header_value (node2, zyre_uuid (node1), "X-HELLO");
+    assert (streq (value, "World"));
+    zstr_free (&value);
 
     //  One node shouts to GLOBAL
     zyre_shouts (node1, "GLOBAL", "Hello, World");

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -447,6 +447,18 @@ zyre_node_recv_api (zyre_node_t *self)
         zstr_free (&uuid);
     }
     else
+    if (streq (command, "PEER HEADER")) {
+        char *uuid = zmsg_popstr (request);
+        char *key = zmsg_popstr (request);
+        zyre_peer_t *peer = (zyre_peer_t *) zhash_lookup (self->peers, (void *) uuid);
+        if (!peer)
+            zstr_send (self->pipe, "");
+        else
+            zstr_send (self->pipe, zyre_peer_header (peer, key, NULL));
+        zstr_free (&uuid);
+        zstr_free (&key);
+    }
+    else
     if (streq (command, "PEER GROUPS"))
         zsock_send (self->pipe, "p", zhash_keys (self->peer_groups));
     else


### PR DESCRIPTION
Problem: Can't retrieve peer header information after first ENTER message.

Solution: Getter method to retrieve header value for a specific peer.
