### PR TITLE
Problem: autogen.sh shebang not always works

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/sh
+#!/bin/sh
 #################################################################
 #   GENERATED SOURCE CODE, DO NOT EDIT EXCEPT EXPERIMENTALLY    #
 #   Please read the README.txt file in the model directory.     #


### PR DESCRIPTION
Currently autogen.sh has shebang that requires `sh` to be in `/usr/bin`. Usually it's just `/bin/sh`. 
Some systems have it also symlinked, although that's not the case, for example, for Mac Os X.

`/bin/sh` shebang should work for any system.
