### PR TITLE
Revert "zyre_new uses its address instead of generating random ids."

### DIFF
--- a/src/zyre.c
+++ b/src/zyre.c
@@ -90,17 +90,17 @@ zyre_new (const char *name)
     //  Create front-to-back pipe pair for data traffic
     self->inbox = zsock_new (ZMQ_PAIR);
     assert (self->inbox);
-
-    // Use the unique address of the node to identify the inproc endpoint.
-    char endpoint [40];
-    sprintf (endpoint, "inproc://zyre-%p\n", (void*)self);
-    int errcode = zsock_bind (self->inbox, "%s", endpoint);
-    assert (errcode == 0);
-
+    char endpoint [32];
+    while (true) {
+        sprintf (endpoint, "inproc://zyre-%04x-%04x\n",
+                 randof (0x10000), randof (0x10000));
+        if (zsock_bind (self->inbox, "%s", endpoint) == 0)
+            break;
+    }
     //  Create other half of traffic pipe
     zsock_t *outbox = zsock_new_pair (endpoint);
     assert (outbox);
-
+    
     //  Start node engine and wait for it to be ready
     self->actor = zactor_new (zyre_node_actor, outbox);
     assert (self->actor);


### PR DESCRIPTION
This reverts commit d3335b2c8586438d396831017d6ba6caa5c7187b.

Problem: while this commit seemed logical and clean, it introduced a
random failure, when creating, destroying, and recreating zyre
objects. That is, they would bind to the same inproc endpoint, as
the same pointer address was reallocated by the heap. The result is
random failures in "make check" and other applications.

Solution: switch back to the old random/loop approach.
