### PR TITLE
Problem: creating pipe by hand is fragile

### DIFF
--- a/src/zyre.c
+++ b/src/zyre.c
@@ -88,18 +88,8 @@ zyre_new (const char *name)
     assert (self);
 
     //  Create front-to-back pipe pair for data traffic
-    self->inbox = zsock_new (ZMQ_PAIR);
-    assert (self->inbox);
-    char endpoint [32];
-    while (true) {
-        sprintf (endpoint, "inproc://zyre-%04x-%04x\n",
-                 randof (0x10000), randof (0x10000));
-        if (zsock_bind (self->inbox, "%s", endpoint) == 0)
-            break;
-    }
-    //  Create other half of traffic pipe
-    zsock_t *outbox = zsock_new_pair (endpoint);
-    assert (outbox);
+    zsock_t *outbox;
+    self->inbox = zsys_create_pipe (&outbox);
     
     //  Start node engine and wait for it to be ready
     self->actor = zactor_new (zyre_node_actor, outbox);


### PR DESCRIPTION
I'm not sure the HWMs are set properly, and they're certainly not
using the zsys environment as they should be.

Solution: use zsys_create_pipe (). Note, this depends on CZMQ PR
being merged.
