### PR TITLE
Problem: zyre_stop does not wait for signal

### DIFF
--- a/src/zyre.c
+++ b/src/zyre.c
@@ -327,6 +327,7 @@ zyre_stop (zyre_t *self)
 {
     assert (self);
     zstr_sendx (self->actor, "STOP", NULL);
+    zsock_wait (self->actor);
 }
 
 


### PR DESCRIPTION
Solution: make it wait properly.
