### PR TITLE
added zyre_get_peer_name method, fixes #297

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -170,6 +170,11 @@ ZYRE_EXPORT zlist_t *
 ZYRE_EXPORT char *
     zyre_peer_address(zyre_t *self, const char *peer);
 
+//  Return the name of a connected peer. Caller owns the
+//  string.
+ZYRE_EXPORT char *
+    zyre_get_peer_name(zyre_t *self, const char *peer);
+
 //  Return the value of a header of a conected peer. 
 //  Returns null if peer or key doesn't exits. Caller
 //  owns the string

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -476,6 +476,21 @@ zyre_peer_address(zyre_t *self, const char *peer)
 }
 
 //  --------------------------------------------------------------------------
+//  Return the name of a connected peer. Caller owns the
+//  string.
+
+char *
+zyre_get_peer_name(zyre_t *self, const char *peer)
+{
+    assert (self);
+    char *address;
+    zstr_sendm (self->actor, "PEER NAME");
+    zstr_send (self->actor, peer);
+    zsock_recv (self->actor, "s", &address);
+    return address;
+}
+
+//  --------------------------------------------------------------------------
 //  Return the value of a header of a conected peer. 
 //  Returns null if peer or key doesn't exits. Caller
 //  owns the string
@@ -655,6 +670,9 @@ zyre_test (bool verbose)
     char *name = zmsg_popstr (msg);
     assert (streq (name, "node1"));
     zstr_free (&name);
+    char *peer_name = zyre_get_peer_name(node2, peerid);
+    assert (streq (peer_name, "node1"));
+    zstr_free (&peer_name);
     zframe_t *headers_packed = zmsg_pop (msg);
     char *peeraddress = zmsg_popstr (msg);
     char *peerendpoint = zyre_peer_address (node2, peerid);

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -444,6 +444,14 @@ zyre_node_recv_api (zyre_node_t *self)
         zstr_free (&uuid);
     }
     else
+    if (streq (command, "PEER NAME")) {
+        char *uuid = zmsg_popstr (request);
+        zyre_peer_t *peer = (zyre_peer_t *) zhash_lookup (self->peers, uuid);
+        assert (peer);
+        zsock_send (self->pipe, "s", zyre_peer_name (peer));
+        zstr_free (&uuid);
+    }
+    else
     if (streq (command, "PEER HEADER")) {
         char *uuid = zmsg_popstr (request);
         char *key = zmsg_popstr (request);


### PR DESCRIPTION
zyre_peer_name is already taken by the zyre_peer class. Alternative would be to use the zyre_name method with peer as an argument?
