### PR TITLE
Problem: Dificult to determine when to stop processing events

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ frames provide further values:
         a peer has sent this node a message
     SHOUT fromnode groupname message
         a peer has sent one of our groups a message
+    STOP fromnode
+        this node has stopped - no further events will be received
 
 In SHOUT and WHISPER the message is a single frame in this version
 of Zyre. In ENTER, the headers frame contains a packed dictionary,

--- a/api/zyre_event.xml
+++ b/api/zyre_event.xml
@@ -10,6 +10,7 @@
         <constant name="exit" value="4" />
         <constant name="whisper" value="5" />
         <constant name="shout" value="6" />
+        <constant name="stop" value="7" />
     </enum>
 
     <constructor>

--- a/bindings/python/zyre.py
+++ b/bindings/python/zyre.py
@@ -306,6 +306,7 @@ class ZyreEvent(object):
         'exit': 4,
         'whisper': 5,
         'shout': 6,
+        'stop': 7,
     }
 
     Type_out = {
@@ -315,6 +316,7 @@ class ZyreEvent(object):
          4: 'exit',
          5: 'whisper',
          6: 'shout',
+         7: 'stop',
     }
 
     def __init__(self, *args):

--- a/bindings/python/zyre.py
+++ b/bindings/python/zyre.py
@@ -32,10 +32,6 @@ class zyre_t(Structure):
     pass # Empty - only for type checking
 zyre_p = POINTER(zyre_t)
 
-class zlist_t(Structure):
-    pass # Empty - only for type checking
-zlist_p = POINTER(zlist_t)
-
 class zsock_t(Structure):
     pass # Empty - only for type checking
 zsock_p = POINTER(zsock_t)
@@ -88,11 +84,11 @@ lib.zyre_whispers.restype = c_int
 lib.zyre_whispers.argtypes = [zyre_p, c_char_p, c_char_p]
 lib.zyre_shouts.restype = c_int
 lib.zyre_shouts.argtypes = [zyre_p, c_char_p, c_char_p]
-lib.zyre_peers.restype = zlist_p
+lib.zyre_peers.restype = czmq.zlist_p
 lib.zyre_peers.argtypes = [zyre_p]
-lib.zyre_own_groups.restype = zlist_p
+lib.zyre_own_groups.restype = czmq.zlist_p
 lib.zyre_own_groups.argtypes = [zyre_p]
-lib.zyre_peer_groups.restype = zlist_p
+lib.zyre_peer_groups.restype = czmq.zlist_p
 lib.zyre_peer_groups.argtypes = [zyre_p]
 lib.zyre_peer_address.restype = POINTER(c_char)
 lib.zyre_peer_address.argtypes = [zyre_p, c_char_p]
@@ -235,17 +231,17 @@ Destroys message after sending"""
     def peers(self):
         """Return zlist of current peer ids. The caller owns this list and should
 destroy it when finished with it."""
-        return Zlist(lib.zyre_peers(self._as_parameter_), True)
+        return czmq.Zlist(lib.zyre_peers(self._as_parameter_), True)
 
     def own_groups(self):
         """Return zlist of currently joined groups. The caller owns this list and
 should destroy it when finished with it."""
-        return Zlist(lib.zyre_own_groups(self._as_parameter_), True)
+        return czmq.Zlist(lib.zyre_own_groups(self._as_parameter_), True)
 
     def peer_groups(self):
         """Return zlist of groups known through connected peers. The caller owns this
 list and should destroy it when finished with it."""
-        return Zlist(lib.zyre_peer_groups(self._as_parameter_), True)
+        return czmq.Zlist(lib.zyre_peer_groups(self._as_parameter_), True)
 
     def peer_address(self, peer):
         """Return the endpoint of a connected peer. Caller owns the string."""
@@ -259,7 +255,7 @@ owns the string"""
 
     def socket(self):
         """Return socket for talking to the Zyre node, for polling"""
-        return Zsock(lib.zyre_socket(self._as_parameter_), False)
+        return lib.zyre_socket(self._as_parameter_)
 
     def dump(self):
         """Prints Zyre node information"""

--- a/include/zyre_event.h
+++ b/include/zyre_event.h
@@ -40,7 +40,8 @@ typedef enum {
     ZYRE_EVENT_LEAVE = 3,
     ZYRE_EVENT_EXIT = 4,
     ZYRE_EVENT_WHISPER = 5,
-    ZYRE_EVENT_SHOUT = 6
+    ZYRE_EVENT_SHOUT = 6,
+    ZYRE_EVENT_STOP = 7
 } zyre_event_type_t;
 
 //  Constructor: receive an event from the zyre node, wraps zyre_recv.

--- a/project.xml
+++ b/project.xml
@@ -8,6 +8,7 @@
     <version major = "1" minor = "1" patch = "0" />
     <use project = "czmq">
         <class name="zhash" />
+        <class name="zlist" />
         <class name="zmsg" />
     </use>
 

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -693,10 +693,18 @@ zyre_test (bool verbose)
     assert (streq (command, "SHOUT"));
     zstr_free (&command);
     zmsg_destroy (&msg);
-    
-    zyre_stop (node1);
+
     zyre_stop (node2);
-    
+
+    msg = zyre_recv (node2);
+    assert (msg);
+    command = zmsg_popstr (msg);
+    assert (streq (command, "STOP"));
+    zstr_free (&command);
+    zmsg_destroy (&msg);
+
+    zyre_stop (node1);
+
     zyre_destroy (&node1);
     zyre_destroy (&node2);
     //  @end

--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -105,6 +105,10 @@ zyre_event_new (zyre_t *node)
         msg = NULL;
     }
     else
+    if (streq (type, "STOP")) {
+        self->type = ZYRE_EVENT_STOP;
+    }
+    else
         zsys_warning ("bad message received from node: %s\n", type);
     
     free (type);

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -244,6 +244,9 @@ zyre_node_stop (zyre_node_t *self)
     }
     //  Stop polling on inbox
     zpoller_remove (self->poller, self->inbox);
+    zstr_sendm (self->outbox, "STOP");
+    zstr_sendm (self->outbox, zuuid_str (self->uuid));
+    zstr_send (self->outbox, self->name);
     return 0;
 }
 


### PR DESCRIPTION
Solution: Add a STOP event send from the local node in response to zyre_stop.

Motivation: A common pattern when using Zyre is to have a background
thread process zyre events, and for the main thread to control program
execution. If we want to terminate the program, we must create a
separate channel to communicate the stop signal to the background
thread, which means we cannot use a simple while loop around zyre_recv
or zyre_event_new, complicating processing unnecessarily. Now we simply
listen for the stop event over the same channel, and terminate event
processing gracefully.