### PR TITLE
Problem: Print method required by CLASS api, missing print method on zyre_event

### DIFF
--- a/api/zyre.xml
+++ b/api/zyre.xml
@@ -187,10 +187,6 @@
         <return type="zsock" />
     </method>
 
-    <method name="dump">
-        Prints Zyre node information
-    </method>
-
     <method name="version" singleton="1">
         Return the Zyre version for run-time API detection
         <argument name="major" type="integer" by_reference="1" />

--- a/bindings/python/zyre.py
+++ b/bindings/python/zyre.py
@@ -46,6 +46,8 @@ lib.zyre_new.restype = zyre_p
 lib.zyre_new.argtypes = [c_char_p]
 lib.zyre_destroy.restype = None
 lib.zyre_destroy.argtypes = [POINTER(zyre_p)]
+lib.zyre_print.restype = None
+lib.zyre_print.argtypes = [zyre_p]
 lib.zyre_uuid.restype = c_char_p
 lib.zyre_uuid.argtypes = [zyre_p]
 lib.zyre_name.restype = c_char_p
@@ -96,8 +98,6 @@ lib.zyre_peer_header_value.restype = POINTER(c_char)
 lib.zyre_peer_header_value.argtypes = [zyre_p, c_char_p, c_char_p]
 lib.zyre_socket.restype = zsock_p
 lib.zyre_socket.argtypes = [zyre_p]
-lib.zyre_dump.restype = None
-lib.zyre_dump.argtypes = [zyre_p]
 lib.zyre_version.restype = None
 lib.zyre_version.argtypes = [POINTER(c_int), POINTER(c_int), POINTER(c_int)]
 lib.zyre_test.restype = None
@@ -123,6 +123,10 @@ specify NULL, Zyre generates a randomized node name from the UUID."""
 messages it is sending or receiving will be discarded."""
         if self.allow_destruct:
             lib.zyre_destroy(byref(self._as_parameter_))
+
+    def print(self):
+        """Print properties of object"""
+        return lib.zyre_print(self._as_parameter_)
 
     def uuid(self):
         """Return our node UUID string, after successful initialization"""
@@ -257,10 +261,6 @@ owns the string"""
         """Return socket for talking to the Zyre node, for polling"""
         return lib.zyre_socket(self._as_parameter_)
 
-    def dump(self):
-        """Prints Zyre node information"""
-        return lib.zyre_dump(self._as_parameter_)
-
     @staticmethod
     def version(major, minor, patch):
         """Return the Zyre version for run-time API detection"""
@@ -277,6 +277,8 @@ lib.zyre_event_new.restype = zyre_event_p
 lib.zyre_event_new.argtypes = [zyre_p]
 lib.zyre_event_destroy.restype = None
 lib.zyre_event_destroy.argtypes = [POINTER(zyre_event_p)]
+lib.zyre_event_print.restype = None
+lib.zyre_event_print.argtypes = [zyre_event_p]
 lib.zyre_event_type.restype = c_int
 lib.zyre_event_type.argtypes = [zyre_event_p]
 lib.zyre_event_sender.restype = c_char_p
@@ -334,6 +336,10 @@ data (WHISPER, SHOUT)."""
         """Destructor; destroys an event instance"""
         if self.allow_destruct:
             lib.zyre_event_destroy(byref(self._as_parameter_))
+
+    def print(self):
+        """Print properties of object"""
+        return lib.zyre_event_print(self._as_parameter_)
 
     def type(self):
         """Returns event type, which is a zyre_event_type_t"""

--- a/bindings/qml/src/QmlZyre.cpp
+++ b/bindings/qml/src/QmlZyre.cpp
@@ -9,6 +9,12 @@
 
 
 ///
+//  Print properties of object
+void QmlZyre::print () {
+    zyre_print (self);
+};
+
+///
 //  Return our node UUID string, after successful initialization
 const QString QmlZyre::uuid () {
     return QString (zyre_uuid (self));
@@ -195,12 +201,6 @@ QString QmlZyre::peerHeaderValue (const QString &peer, const QString &name) {
 //  Return socket for talking to the Zyre node, for polling
 zsock_t *QmlZyre::socket () {
     return zyre_socket (self);
-};
-
-///
-//  Prints Zyre node information
-void QmlZyre::dump () {
-    zyre_dump (self);
 };
 
 

--- a/bindings/qml/src/QmlZyre.h
+++ b/bindings/qml/src/QmlZyre.h
@@ -28,6 +28,9 @@ public:
     static QObject* qmlAttachedProperties(QObject* object); // defined in QmlZyre.cpp
     
 public slots:
+    //  Print properties of object
+    void print ();
+
     //  Return our node UUID string, after successful initialization
     const QString uuid ();
 
@@ -135,9 +138,6 @@ public slots:
 
     //  Return socket for talking to the Zyre node, for polling
     zsock_t *socket ();
-
-    //  Prints Zyre node information
-    void dump ();
 };
 
 class QmlZyreAttached : public QObject

--- a/bindings/qml/src/QmlZyreEvent.cpp
+++ b/bindings/qml/src/QmlZyreEvent.cpp
@@ -9,6 +9,12 @@
 
 
 ///
+//  Print properties of object
+void QmlZyreEvent::print () {
+    zyre_event_print (self);
+};
+
+///
 //  Returns event type, which is a zyre_event_type_t
 zyre_event_type_t QmlZyreEvent::type () {
     return zyre_event_type (self);

--- a/bindings/qml/src/QmlZyreEvent.h
+++ b/bindings/qml/src/QmlZyreEvent.h
@@ -28,6 +28,9 @@ public:
     static QObject* qmlAttachedProperties(QObject* object); // defined in QmlZyreEvent.cpp
     
 public slots:
+    //  Print properties of object
+    void print ();
+
     //  Returns event type, which is a zyre_event_type_t
     zyre_event_type_t type ();
 

--- a/bindings/ruby/lib/zyre/ffi.rb
+++ b/bindings/ruby/lib/zyre/ffi.rb
@@ -36,6 +36,7 @@ module Zyre
       
       attach_function :zyre_new, [:string], :pointer, **opts
       attach_function :zyre_destroy, [:pointer], :void, **opts
+      attach_function :zyre_print, [:pointer], :void, **opts
       attach_function :zyre_uuid, [:pointer], :string, **opts
       attach_function :zyre_name, [:pointer], :string, **opts
       attach_function :zyre_set_header, [:pointer, :string, :string, :varargs], :void, **opts
@@ -61,7 +62,6 @@ module Zyre
       attach_function :zyre_peer_address, [:pointer, :string], :pointer, **opts
       attach_function :zyre_peer_header_value, [:pointer, :string, :string], :pointer, **opts
       attach_function :zyre_socket, [:pointer], :pointer, **opts
-      attach_function :zyre_dump, [:pointer], :void, **opts
       attach_function :zyre_version, [:pointer, :pointer, :pointer], :void, **opts
       attach_function :zyre_test, [:bool], :void, **opts
       
@@ -69,6 +69,7 @@ module Zyre
       
       attach_function :zyre_event_new, [:pointer], :pointer, **opts
       attach_function :zyre_event_destroy, [:pointer], :void, **opts
+      attach_function :zyre_event_print, [:pointer], :void, **opts
       attach_function :zyre_event_type, [:pointer], :pointer, **opts
       attach_function :zyre_event_sender, [:pointer], :string, **opts
       attach_function :zyre_event_name, [:pointer], :string, **opts

--- a/bindings/ruby/lib/zyre/ffi/event.rb
+++ b/bindings/ruby/lib/zyre/ffi/event.rb
@@ -67,6 +67,13 @@ module Zyre
         result
       end
       
+      # Print properties of object
+      def print
+        raise DestroyedError unless @ptr
+        result = ::Zyre::FFI.zyre_event_print @ptr
+        result
+      end
+      
       # Returns event type, which is a zyre_event_type_t
       def type
         raise DestroyedError unless @ptr

--- a/bindings/ruby/lib/zyre/ffi/zyre.rb
+++ b/bindings/ruby/lib/zyre/ffi/zyre.rb
@@ -69,6 +69,13 @@ module Zyre
         result
       end
       
+      # Print properties of object
+      def print
+        raise DestroyedError unless @ptr
+        result = ::Zyre::FFI.zyre_print @ptr
+        result
+      end
+      
       # Return our node UUID string, after successful initialization
       def uuid
         raise DestroyedError unless @ptr
@@ -293,13 +300,6 @@ module Zyre
       def socket
         raise DestroyedError unless @ptr
         result = ::Zyre::FFI.zyre_socket @ptr
-        result
-      end
-      
-      # Prints Zyre node information
-      def dump
-        raise DestroyedError unless @ptr
-        result = ::Zyre::FFI.zyre_dump @ptr
         result
       end
       

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -48,6 +48,10 @@ ZYRE_EXPORT zyre_t *
 ZYRE_EXPORT void
     zyre_destroy (zyre_t **self_p);
 
+//  Print properties of object
+ZYRE_EXPORT void
+    zyre_print (zyre_t *self);
+
 //  Return our node UUID string, after successful initialization
 ZYRE_EXPORT const char *
     zyre_uuid (zyre_t *self);
@@ -181,10 +185,6 @@ ZYRE_EXPORT char *
 ZYRE_EXPORT zsock_t *
     zyre_socket (zyre_t *self);
 
-//  Prints Zyre node information
-ZYRE_EXPORT void
-    zyre_dump (zyre_t *self);
-
 //  Return the Zyre version for run-time API detection
 ZYRE_EXPORT void
     zyre_version (int *major, int *minor, int *patch);
@@ -193,6 +193,8 @@ ZYRE_EXPORT void
 ZYRE_EXPORT void
     zyre_test (bool verbose);
 //  @end
+
+#define zyre_dump(z) zyre_print((z))
 
 #ifdef __cplusplus
 }

--- a/include/zyre_event.h
+++ b/include/zyre_event.h
@@ -54,6 +54,10 @@ ZYRE_EXPORT zyre_event_t *
 ZYRE_EXPORT void
     zyre_event_destroy (zyre_event_t **self_p);
 
+//  Print properties of object
+ZYRE_EXPORT void
+    zyre_event_print (zyre_event_t *self);
+
 //  Returns event type, which is a zyre_event_type_t
 ZYRE_EXPORT zyre_event_type_t
     zyre_event_type (zyre_event_t *self);

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -535,7 +535,7 @@ zyre_socket (zyre_t *self)
 //  Prints zyre node information
 
 void
-zyre_dump (zyre_t *self)
+zyre_print (zyre_t *self)
 {
     zstr_send (self->actor, "DUMP");
 }

--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -137,6 +137,63 @@ zyre_event_destroy (zyre_event_t **self_p)
     }
 }
 
+static int
+zyre_event_log_pair (const char *key, void *item, void *argument)
+{
+    zsys_info ("   - %s: %s", key, (const char *)item);
+    return 0;
+}
+
+void
+zyre_event_print (zyre_event_t *self)
+{
+    zsys_info ("zyre_event:");
+    zsys_info (" - from name=%s uuid=%s", zyre_event_name(self), zyre_event_sender(self));
+
+    switch (self->type)
+    {
+    case ZYRE_EVENT_ENTER:
+        zsys_info (" - type=ENTER");
+        zsys_info (" - headers=%zu:", zhash_size (self->headers));
+        zhash_foreach (self->headers, (zhash_foreach_fn *) zyre_event_log_pair, self);
+        zsys_info (" - address=%s", zyre_event_address(self));
+        break;
+
+    case ZYRE_EVENT_EXIT:
+        zsys_info (" - type=EXIT");
+        break;
+
+    case ZYRE_EVENT_STOP:
+        zsys_info (" - type=STOP");
+        break;
+
+    case ZYRE_EVENT_JOIN:
+        zsys_info (" - type=JOIN");
+        zsys_info (" - group=%s", zyre_event_group(self));
+        break;
+
+    case ZYRE_EVENT_LEAVE:
+        zsys_info (" - type=LEAVE");
+        zsys_info (" - group=%s", zyre_event_group(self));
+        break;
+
+    case ZYRE_EVENT_SHOUT:
+        zsys_info (" - type=SHOUT");
+        zsys_info (" - message:");
+        zmsg_print (self->msg);
+        break;
+
+    case ZYRE_EVENT_WHISPER:
+        zsys_info (" - type=WHISPER");
+        zsys_info (" - message:");
+        zmsg_print (self->msg);
+        break;
+
+    default:
+        zsys_info (" - type=UNKNOWN");
+        break;
+    }
+}
 
 //  --------------------------------------------------------------------------
 //  Returns event type, which is a zyre_event_type_t

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -285,6 +285,7 @@ zyre_node_dump (zyre_node_t *self)
 {
     zsys_info ("zyre_node: dump state");
     zsys_info (" - name=%s uuid=%s", self->name, zuuid_str (self->uuid));
+
     zsys_info (" - endpoint=%s", self->endpoint);
     if (self->beacon_port) 
         zsys_info (" - discovery=beacon port=%d interval=%zu",


### PR DESCRIPTION
Solution: Rename, use macro to maintain compatibility, and implement zyre_event_print