### PR TITLE
Problem: Out of sync with current zproject capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,8 @@ project(zyre)
 enable_language(C)
 enable_testing()
 
-set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+set(SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+set(BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 ########################################################################
 # determine version
@@ -45,7 +45,7 @@ if (NOT HAVE_NET_IF_H)
     CHECK_INCLUDE_FILE("net/if.h" HAVE_NET_IF_H)
 endif()
 
-file(WRITE ${BINARY_DIR}/platform.h.in "
+file(WRITE "${BINARY_DIR}/platform.h.in" "
 #cmakedefine HAVE_LINUX_WIRELESS_H
 #cmakedefine HAVE_NET_IF_H
 #cmakedefine HAVE_NET_IF_MEDIA_H
@@ -53,13 +53,13 @@ file(WRITE ${BINARY_DIR}/platform.h.in "
 #cmakedefine HAVE_FREEIFADDRS
 ")
 
-configure_file(${BINARY_DIR}/platform.h.in ${BINARY_DIR}/platform.h)
+configure_file("${BINARY_DIR}/platform.h.in" "${BINARY_DIR}/platform.h")
 
 #The MSVC C compiler is too out of date,
 #so the sources have to be compiled as c++
 if (MSVC)
     enable_language(CXX)
-    file(GLOB sources ${SOURCE_DIR}/src/*.c)
+    file(GLOB sources "${SOURCE_DIR}/src/*.c")
     set_source_files_properties(${sources} PROPERTIES LANGUAGE CXX)
     set(MORE_LIBRARIES ws2_32 Rpcrt4 Iphlpapi)
 endif()
@@ -74,7 +74,7 @@ if (CYGWIN)
     set(MORE_LIBRARIES -luuid)
 endif()
 
-list(APPEND CMAKE_MODULE_PATH ${SOURCE_DIR})
+list(APPEND CMAKE_MODULE_PATH "${SOURCE_DIR}")
 
 ########################################################################
 # ZMQ dependency
@@ -108,8 +108,7 @@ install(FILES ${zyre_headers} DESTINATION include)
 ########################################################################
 # library
 ########################################################################
-include_directories(${BINARY_DIR})
-include_directories(${SOURCE_DIR}/include)
+include_directories("${BINARY_DIR}" "${SOURCE_DIR}/include")
 set (zyre_sources
     src/zyre.c
     src/zyre_event.c
@@ -119,13 +118,16 @@ set (zyre_sources
     src/zyre_node.c
 )
 source_group ("Source Files" FILES ${zyre_sources})
-add_library(zyre SHARED ${zyre_sources})
+if (NOT DEFINED BUILD_SHARED_LIBS)
+    SET(BUILD_SHARED_LIBS ON)
+endif()
+add_library(zyre ${zyre_sources})
 set_target_properties(zyre PROPERTIES DEFINE_SYMBOL "LIBZYRE_EXPORTS")
 target_link_libraries(zyre ${ZEROMQ_LIBRARIES} ${MORE_LIBRARIES})
 
 install(TARGETS zyre
-    LIBRARY DESTINATION lib${LIB_SUFFIX} # .so file
-    ARCHIVE DESTINATION lib${LIB_SUFFIX} # .lib file
+    LIBRARY DESTINATION "lib${LIB_SUFFIX}" # .so file
+    ARCHIVE DESTINATION "lib${LIB_SUFFIX}" # .lib file
     RUNTIME DESTINATION bin              # .dll file
 )
 
@@ -138,19 +140,19 @@ set(exec_prefix "\${prefix}")
 set(libdir "\${prefix}/lib${LIB_SUFFIX}")
 set(includedir "\${prefix}/include")
 configure_file(
-    ${SOURCE_DIR}/src/libzyre.pc.in
-    ${BINARY_DIR}/libzyre.pc
+    "${SOURCE_DIR}/src/libzyre.pc.in"
+    "${BINARY_DIR}/libzyre.pc"
 @ONLY)
 
 install(
-    FILES ${BINARY_DIR}/libzyre.pc
-    DESTINATION lib${LIB_SUFFIX}/pkgconfig
+    FILES "${BINARY_DIR}/libzyre.pc"
+    DESTINATION "lib${LIB_SUFFIX}/pkgconfig"
 )
 
 ########################################################################
 # tests
 ########################################################################
-add_executable(zyre_selftest ${SOURCE_DIR}/src/zyre_selftest.c)
+add_executable(zyre_selftest "${SOURCE_DIR}/src/zyre_selftest.c")
 target_link_libraries(zyre_selftest zyre ${ZEROMQ_LIBRARIES})
 add_test(zyre_selftest zyre_selftest)
 

--- a/api/zyre.xml
+++ b/api/zyre.xml
@@ -150,33 +150,29 @@
     </method>
 
     <method name="peers">
-        Return zlist of current peer ids. The caller owns this list and should
-        destroy it when finished with it.
+        Return zlist of current peer ids.
         <return type="zlist" fresh="1" />
     </method>
 
     <method name="own_groups">
-        Return zlist of currently joined groups. The caller owns this list and
-        should destroy it when finished with it.
+        Return zlist of currently joined groups.
         <return type="zlist" fresh="1" />
     </method>
 
     <method name="peer_groups">
-        Return zlist of groups known through connected peers. The caller owns this
-        list and should destroy it when finished with it.
+        Return zlist of groups known through connected peers.
         <return type="zlist" fresh="1" />
     </method>
 
     <method name="peer_address">
-        Return the endpoint of a connected peer. Caller owns the string.
+        Return the endpoint of a connected peer.
         <argument name="peer" type="string" />
         <return type="string" fresh="1" />
     </method>
 
     <method name="peer_header_value">
         Return the value of a header of a conected peer. 
-        Returns null if peer or key doesn't exits. Caller
-        owns the string
+        Returns null if peer or key doesn't exist.
         <argument name="peer" type="string" />
         <argument name="name" type="string" />
         <return type="string" fresh="1" />

--- a/bindings/qml/src/QmlZyre.cpp
+++ b/bindings/qml/src/QmlZyre.cpp
@@ -9,7 +9,7 @@
 
 
 ///
-//  Print properties of object
+//  Print properties of the zyre object.
 void QmlZyre::print () {
     zyre_print (self);
 };
@@ -157,28 +157,25 @@ int QmlZyre::shouts (const QString &group, const QString &format) {
 };
 
 ///
-//  Return zlist of current peer ids. The caller owns this list and should
-//  destroy it when finished with it.                                     
+//  Return zlist of current peer ids.
 zlist_t *QmlZyre::peers () {
     return zyre_peers (self);
 };
 
 ///
-//  Return zlist of currently joined groups. The caller owns this list and
-//  should destroy it when finished with it.                              
+//  Return zlist of currently joined groups.
 zlist_t *QmlZyre::ownGroups () {
     return zyre_own_groups (self);
 };
 
 ///
-//  Return zlist of groups known through connected peers. The caller owns this
-//  list and should destroy it when finished with it.                         
+//  Return zlist of groups known through connected peers.
 zlist_t *QmlZyre::peerGroups () {
     return zyre_peer_groups (self);
 };
 
 ///
-//  Return the endpoint of a connected peer. Caller owns the string.
+//  Return the endpoint of a connected peer.
 QString QmlZyre::peerAddress (const QString &peer) {
     char *retStr_ = zyre_peer_address (self, peer.toUtf8().data());
     QString retQStr_ = QString (retStr_);
@@ -188,8 +185,7 @@ QString QmlZyre::peerAddress (const QString &peer) {
 
 ///
 //  Return the value of a header of a conected peer. 
-//  Returns null if peer or key doesn't exits. Caller
-//  owns the string                                  
+//  Returns null if peer or key doesn't exist.       
 QString QmlZyre::peerHeaderValue (const QString &peer, const QString &name) {
     char *retStr_ = zyre_peer_header_value (self, peer.toUtf8().data(), name.toUtf8().data());
     QString retQStr_ = QString (retStr_);

--- a/bindings/qml/src/QmlZyre.h
+++ b/bindings/qml/src/QmlZyre.h
@@ -28,7 +28,7 @@ public:
     static QObject* qmlAttachedProperties(QObject* object); // defined in QmlZyre.cpp
     
 public slots:
-    //  Print properties of object
+    //  Print properties of the zyre object.
     void print ();
 
     //  Return our node UUID string, after successful initialization
@@ -116,24 +116,20 @@ public slots:
     //  Send formatted string to a named group
     int shouts (const QString &group, const QString &format);
 
-    //  Return zlist of current peer ids. The caller owns this list and should
-    //  destroy it when finished with it.                                     
+    //  Return zlist of current peer ids.
     zlist_t *peers ();
 
-    //  Return zlist of currently joined groups. The caller owns this list and
-    //  should destroy it when finished with it.                              
+    //  Return zlist of currently joined groups.
     zlist_t *ownGroups ();
 
-    //  Return zlist of groups known through connected peers. The caller owns this
-    //  list and should destroy it when finished with it.                         
+    //  Return zlist of groups known through connected peers.
     zlist_t *peerGroups ();
 
-    //  Return the endpoint of a connected peer. Caller owns the string.
+    //  Return the endpoint of a connected peer.
     QString peerAddress (const QString &peer);
 
     //  Return the value of a header of a conected peer. 
-    //  Returns null if peer or key doesn't exits. Caller
-    //  owns the string                                  
+    //  Returns null if peer or key doesn't exist.       
     QString peerHeaderValue (const QString &peer, const QString &name);
 
     //  Return socket for talking to the Zyre node, for polling

--- a/bindings/qml/src/QmlZyreEvent.cpp
+++ b/bindings/qml/src/QmlZyreEvent.cpp
@@ -9,7 +9,7 @@
 
 
 ///
-//  Print properties of object
+//  Print properties of the zyre event object.
 void QmlZyreEvent::print () {
     zyre_event_print (self);
 };

--- a/bindings/qml/src/QmlZyreEvent.h
+++ b/bindings/qml/src/QmlZyreEvent.h
@@ -28,7 +28,7 @@ public:
     static QObject* qmlAttachedProperties(QObject* object); // defined in QmlZyreEvent.cpp
     
 public slots:
-    //  Print properties of object
+    //  Print properties of the zyre event object.
     void print ();
 
     //  Returns event type, which is a zyre_event_type_t

--- a/bindings/ruby/lib/zyre/ffi/event.rb
+++ b/bindings/ruby/lib/zyre/ffi/event.rb
@@ -67,7 +67,7 @@ module Zyre
         result
       end
       
-      # Print properties of object
+      # Print properties of the zyre event object.
       def print
         raise DestroyedError unless @ptr
         result = ::Zyre::FFI.zyre_event_print @ptr

--- a/bindings/ruby/lib/zyre/ffi/zyre.rb
+++ b/bindings/ruby/lib/zyre/ffi/zyre.rb
@@ -69,7 +69,7 @@ module Zyre
         result
       end
       
-      # Print properties of object
+      # Print properties of the zyre object.
       def print
         raise DestroyedError unless @ptr
         result = ::Zyre::FFI.zyre_print @ptr
@@ -253,31 +253,28 @@ module Zyre
         result
       end
       
-      # Return zlist of current peer ids. The caller owns this list and should
-      # destroy it when finished with it.                                     
+      # Return zlist of current peer ids.
       def peers
         raise DestroyedError unless @ptr
         result = ::Zyre::FFI.zyre_peers @ptr
         result
       end
       
-      # Return zlist of currently joined groups. The caller owns this list and
-      # should destroy it when finished with it.                              
+      # Return zlist of currently joined groups.
       def own_groups
         raise DestroyedError unless @ptr
         result = ::Zyre::FFI.zyre_own_groups @ptr
         result
       end
       
-      # Return zlist of groups known through connected peers. The caller owns this
-      # list and should destroy it when finished with it.                         
+      # Return zlist of groups known through connected peers.
       def peer_groups
         raise DestroyedError unless @ptr
         result = ::Zyre::FFI.zyre_peer_groups @ptr
         result
       end
       
-      # Return the endpoint of a connected peer. Caller owns the string.
+      # Return the endpoint of a connected peer.
       def peer_address peer
         raise DestroyedError unless @ptr
         peer = String(peer)
@@ -286,8 +283,7 @@ module Zyre
       end
       
       # Return the value of a header of a conected peer. 
-      # Returns null if peer or key doesn't exits. Caller
-      # owns the string                                  
+      # Returns null if peer or key doesn't exist.       
       def peer_header_value peer, name
         raise DestroyedError unless @ptr
         peer = String(peer)

--- a/configure.ac
+++ b/configure.ac
@@ -254,6 +254,7 @@ AC_TYPE_SSIZE_T
 AC_HEADER_TIME
 AC_TYPE_UINT32_T
 AC_C_VOLATILE
+AC_C_BIGENDIAN
 
 # These options are GNU compiler specific.
 if test "x$GCC" = "xyes"; then

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -48,7 +48,7 @@ ZYRE_EXPORT zyre_t *
 ZYRE_EXPORT void
     zyre_destroy (zyre_t **self_p);
 
-//  Print properties of object
+//  Print properties of the zyre object.
 ZYRE_EXPORT void
     zyre_print (zyre_t *self);
 
@@ -156,28 +156,29 @@ ZYRE_EXPORT int
 ZYRE_EXPORT int
     zyre_shouts (zyre_t *self, const char *group, const char *format, ...) CHECK_PRINTF (3);
 
-//  Return zlist of current peer ids. The caller owns this list and should
-//  destroy it when finished with it.                                     
+//  Return zlist of current peer ids.
+//  The caller is responsible for destroying the return value when finished with it.
 ZYRE_EXPORT zlist_t *
     zyre_peers (zyre_t *self);
 
-//  Return zlist of currently joined groups. The caller owns this list and
-//  should destroy it when finished with it.                              
+//  Return zlist of currently joined groups.
+//  The caller is responsible for destroying the return value when finished with it.
 ZYRE_EXPORT zlist_t *
     zyre_own_groups (zyre_t *self);
 
-//  Return zlist of groups known through connected peers. The caller owns this
-//  list and should destroy it when finished with it.                         
+//  Return zlist of groups known through connected peers.
+//  The caller is responsible for destroying the return value when finished with it.
 ZYRE_EXPORT zlist_t *
     zyre_peer_groups (zyre_t *self);
 
-//  Return the endpoint of a connected peer. Caller owns the string.
+//  Return the endpoint of a connected peer.
+//  The caller is responsible for destroying the return value when finished with it.
 ZYRE_EXPORT char *
     zyre_peer_address (zyre_t *self, const char *peer);
 
 //  Return the value of a header of a conected peer. 
-//  Returns null if peer or key doesn't exits. Caller
-//  owns the string                                  
+//  Returns null if peer or key doesn't exist.       
+//  The caller is responsible for destroying the return value when finished with it.
 ZYRE_EXPORT char *
     zyre_peer_header_value (zyre_t *self, const char *peer, const char *name);
 

--- a/include/zyre_event.h
+++ b/include/zyre_event.h
@@ -54,7 +54,7 @@ ZYRE_EXPORT zyre_event_t *
 ZYRE_EXPORT void
     zyre_event_destroy (zyre_event_t **self_p);
 
-//  Print properties of object
+//  Print properties of the zyre event object.
 ZYRE_EXPORT void
     zyre_event_print (zyre_event_t *self);
 

--- a/include/zyre_library.h
+++ b/include/zyre_library.h
@@ -27,8 +27,8 @@
     =========================================================================
 */
 
-#ifndef __zyre_library_H_INCLUDED__
-#define __zyre_library_H_INCLUDED__
+#ifndef zyre_library_H_INCLUDED
+#define zyre_library_H_INCLUDED
 
 //  Set up environment for the application
 

--- a/src/zyre_classes.h
+++ b/src/zyre_classes.h
@@ -26,8 +26,8 @@
     =========================================================================
 */
 
-#ifndef __ZYRE_CLASSES_H_INCLUDED__
-#define __ZYRE_CLASSES_H_INCLUDED__
+#ifndef ZYRE_CLASSES_H_INCLUDED
+#define ZYRE_CLASSES_H_INCLUDED
 
 //  External API
 #include "../include/zyre.h"


### PR DESCRIPTION
Solution: Remove hand-written return value 'freshness' information, and
regenerate using zproject, fixing bindings and improving documentation.