### PR TITLE
Problem: zyre client aborts when no headers are set

### DIFF
--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -253,6 +253,8 @@ const char *
 zyre_event_header (zyre_event_t *self, const char *name)
 {
     assert (self);
+    if (!self->headers)
+        return NULL;
     return (const char *)zhash_lookup (self->headers, name);
 }
 


### PR DESCRIPTION
Solution: return NULL for empty hash