### PR TITLE
Problem: zyre testing code segfaults at zyre_event_print

### DIFF
--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -173,13 +173,19 @@ zyre_event_print (zyre_event_t *self)
     case ZYRE_EVENT_SHOUT:
         zsys_info (" - type=SHOUT");
         zsys_info (" - message:");
-        zmsg_print (self->msg);
+        if (self->msg)
+            zmsg_print (self->msg);
+        else
+            zmsg_print ("null");
         break;
 
     case ZYRE_EVENT_WHISPER:
         zsys_info (" - type=WHISPER");
         zsys_info (" - message:");
-        zmsg_print (self->msg);
+        if (self->msg)
+            zmsg_print (self->msg);
+        else
+            zmsg_print ("null");
         break;
     case ZYRE_EVENT_EVASIVE:
 	zsys_info (" - type=EVASIVE");


### PR DESCRIPTION
Solution: the stacktrace contains issues with zmsg_is, so simply test if
self->msg is null or not