### PR TITLE
Revert "Problem: zyre testing code segfaults at zyre_event_print"

### DIFF
--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -173,19 +173,13 @@ zyre_event_print (zyre_event_t *self)
     case ZYRE_EVENT_SHOUT:
         zsys_info (" - type=SHOUT");
         zsys_info (" - message:");
-        if (self->msg)
-            zmsg_print (self->msg);
-        else
-            zmsg_print ("null");
+        zmsg_print (self->msg);
         break;
 
     case ZYRE_EVENT_WHISPER:
         zsys_info (" - type=WHISPER");
         zsys_info (" - message:");
-        if (self->msg)
-            zmsg_print (self->msg);
-        else
-            zmsg_print ("null");
+        zmsg_print (self->msg);
         break;
     case ZYRE_EVENT_EVASIVE:
 	zsys_info (" - type=EVASIVE");


### PR DESCRIPTION
Reverts zeromq/zyre#340

This PR breaks compilation. Catching a null pointer is a good idea but looking at the czmq code this is done by the zmsg_print function thus there's no need to do it here.