### PR TITLE
Fix broken zyre-jni selftest on linux environments

### DIFF
--- a/bindings/jni/src/main/c/zyre.c
+++ b/bindings/jni/src/main/c/zyre.c
@@ -71,18 +71,18 @@ JNIEXPORT jint JNICALL
 Java_org_zeromq_zyre_Zyre__1_1join (JNIEnv *env, jclass c, jlong ptr, jstring str) {
     zyre_t *zyre = (zyre_t *) ptr;
     const char *group = (const char *) (*env)->GetStringUTFChars (env, str, NULL);
+    int rc = zyre_join (zyre, group);
     (*env)->ReleaseStringUTFChars (env, str, group);
-
-    return zyre_join (zyre, group);
+    return rc;
 }
 
 JNIEXPORT jint JNICALL
 Java_org_zeromq_zyre_Zyre__1_1leave (JNIEnv *env, jclass c, jlong ptr, jstring str) {
     zyre_t *zyre = (zyre_t *) ptr;
     const char *group = (const char *) (*env)->GetStringUTFChars (env, str, NULL);
+    int rc = zyre_leave (zyre, group);
     (*env)->ReleaseStringUTFChars (env, str, group);
-
-    return zyre_leave (zyre, group);
+    return rc;
 }
 
 JNIEXPORT jlong JNICALL
@@ -114,27 +114,25 @@ JNIEXPORT jint JNICALL
 Java_org_zeromq_zyre_Zyre__1_1set_1endpoint (JNIEnv *env, jclass c, jlong ptr, jstring endpoint) {
     zyre_t *zyre = (zyre_t *) ptr;
     const char *ep = (const char *) (*env)->GetStringUTFChars (env, endpoint, NULL);
+    int rc = zyre_set_endpoint (zyre, "%s", ep);
     (*env)->ReleaseStringUTFChars (env, endpoint, ep);
-
-    return zyre_set_endpoint (zyre, "%s", ep);
+    return rc;
 }
 
 JNIEXPORT void JNICALL
 Java_org_zeromq_zyre_Zyre__1_1gossip_1bind (JNIEnv *env, jclass c, jlong ptr, jstring endpoint) {
     zyre_t *zyre = (zyre_t *) ptr;
     const char *ep = (const char *) (*env)->GetStringUTFChars (env, endpoint, NULL);
-    (*env)->ReleaseStringUTFChars (env, endpoint, ep);
-
     zyre_gossip_bind (zyre, "%s", ep);
+    (*env)->ReleaseStringUTFChars (env, endpoint, ep);
 }
 
 JNIEXPORT void JNICALL
 Java_org_zeromq_zyre_Zyre__1_1gossip_1connect (JNIEnv *env, jclass c, jlong ptr, jstring endpoint) {
     zyre_t *zyre = (zyre_t *) ptr;
     const char *ep = (const char *) (*env)->GetStringUTFChars (env, endpoint, NULL);
-    (*env)->ReleaseStringUTFChars (env, endpoint, ep);
-
     zyre_gossip_connect (zyre, "%s", ep);
+    (*env)->ReleaseStringUTFChars (env, endpoint, ep);
 }
 
 

--- a/bindings/jni/src/test/java/org/zeromq/zyre/ZyreEventTest.java
+++ b/bindings/jni/src/test/java/org/zeromq/zyre/ZyreEventTest.java
@@ -1,0 +1,41 @@
+package org.zeromq.zyre;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.zeromq.czmq.ZMsg;
+
+public class ZyreEventTest {
+    public static boolean VERBOSE = true;
+
+    @Test
+    public void testZyreEvent() throws InterruptedException {
+        Zyre node1 = new Zyre("node1");
+        node1.setHeader("X-HELLO", "World");
+        if (VERBOSE) {
+            node1.setVerbose();
+        }
+        if (!node1.start()) {
+            node1.close();
+            System.out.println("OK (skipping test, no UDP discovery)");
+            return;
+        }
+        node1.join("GLOBAL");
+
+        Zyre node2 = new Zyre("node2");
+        node2.setHeader("X-HELLO", "World");
+        if (VERBOSE) {
+            node2.setVerbose();
+        }
+        boolean rc = node2.start();
+        Assert.assertTrue(rc);
+        node2.join("GLOBAL");
+
+        Thread.sleep(250);
+
+        ZMsg msg = new ZMsg();
+
+
+        node1.close();
+        node2.close();
+    }
+}


### PR DESCRIPTION
ReleaseStringUTFChars was being called before the actual work was being done