### PR TITLE
Problem: hand-specifying used classes is fragile

### DIFF
--- a/project.xml
+++ b/project.xml
@@ -6,12 +6,7 @@
     >
     <include filename = "license.xml" />
     <version major = "1" minor = "1" patch = "0" />
-    <use project = "czmq">
-        <class name = "zhash" />
-        <class name = "zlist" />
-        <class name = "zmsg" />
-        <class name = "zsock" />
-    </use>
+    <use project = "czmq" />
 
     <class name = "zyre" />
     <class name = "zyre_event" />


### PR DESCRIPTION
Specifically, this asks the user of a project to re-document the
API of that project. If Zyre uses CZMQ then it by definition uses
all CZMQ classes that are exported via its API.

Solution: fix in zproject and remove here.