### PR TITLE
Problem: print method prototype was not generated

### DIFF
--- a/api/zyre.xml
+++ b/api/zyre.xml
@@ -191,6 +191,10 @@
         <return type = "zsock" />
     </method>
 
+    <method name = "print">
+        Print zyre node information to stdout
+    </method>
+
     <method name = "version" singleton = "1">
         Return the Zyre version for run-time API detection
         <argument name = "major" type = "integer" by_reference = "1" />

--- a/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
+++ b/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
@@ -29,16 +29,16 @@ JNIEXPORT jstring JNICALL
 Java_org_zeromq_zyre_Zyre__1_1uuid (JNIEnv *env, jclass c, jlong self)
 {
     char *uuid_ = (char *) zyre_uuid ((zyre_t *) self);
-    jstring return_string_ = (*env)->NewStringUTF (env, uuid_);
-    return return_string_;
+    jstring string = (*env)->NewStringUTF (env, uuid_);
+    return string;
 }
 
 JNIEXPORT jstring JNICALL
 Java_org_zeromq_zyre_Zyre__1_1name (JNIEnv *env, jclass c, jlong self)
 {
     char *name_ = (char *) zyre_name ((zyre_t *) self);
-    jstring return_string_ = (*env)->NewStringUTF (env, name_);
-    return return_string_;
+    jstring string = (*env)->NewStringUTF (env, name_);
+    return string;
 }
 
 JNIEXPORT void JNICALL
@@ -206,10 +206,10 @@ Java_org_zeromq_zyre_Zyre__1_1peerAddress (JNIEnv *env, jclass c, jlong self, js
 {
     char *peer_ = (char *) (*env)->GetStringUTFChars (env, peer, NULL);
     char *peer_address_ = (char *) zyre_peer_address ((zyre_t *) self, peer_);
-    jstring return_string_ = (*env)->NewStringUTF (env, peer_address_);
+    jstring string = (*env)->NewStringUTF (env, peer_address_);
     zstr_free (&peer_address_);
     (*env)->ReleaseStringUTFChars (env, peer, peer_);
-    return return_string_;
+    return string;
 }
 
 JNIEXPORT jstring JNICALL
@@ -218,11 +218,11 @@ Java_org_zeromq_zyre_Zyre__1_1peerHeaderValue (JNIEnv *env, jclass c, jlong self
     char *peer_ = (char *) (*env)->GetStringUTFChars (env, peer, NULL);
     char *name_ = (char *) (*env)->GetStringUTFChars (env, name, NULL);
     char *peer_header_value_ = (char *) zyre_peer_header_value ((zyre_t *) self, peer_, name_);
-    jstring return_string_ = (*env)->NewStringUTF (env, peer_header_value_);
+    jstring string = (*env)->NewStringUTF (env, peer_header_value_);
     zstr_free (&peer_header_value_);
     (*env)->ReleaseStringUTFChars (env, peer, peer_);
     (*env)->ReleaseStringUTFChars (env, name, name_);
-    return return_string_;
+    return string;
 }
 
 JNIEXPORT jlong JNICALL
@@ -230,6 +230,12 @@ Java_org_zeromq_zyre_Zyre__1_1socket (JNIEnv *env, jclass c, jlong self)
 {
     jlong socket_ = (jlong) zyre_socket ((zyre_t *) self);
     return socket_;
+}
+
+JNIEXPORT void JNICALL
+Java_org_zeromq_zyre_Zyre__1_1print (JNIEnv *env, jclass c, jlong self)
+{
+    zyre_print ((zyre_t *) self);
 }
 
 JNIEXPORT void JNICALL

--- a/bindings/jni/src/main/c/org_zeromq_zyre_ZyreEvent.c
+++ b/bindings/jni/src/main/c/org_zeromq_zyre_ZyreEvent.c
@@ -34,24 +34,24 @@ JNIEXPORT jstring JNICALL
 Java_org_zeromq_zyre_ZyreEvent__1_1sender (JNIEnv *env, jclass c, jlong self)
 {
     char *sender_ = (char *) zyre_event_sender ((zyre_event_t *) self);
-    jstring return_string_ = (*env)->NewStringUTF (env, sender_);
-    return return_string_;
+    jstring string = (*env)->NewStringUTF (env, sender_);
+    return string;
 }
 
 JNIEXPORT jstring JNICALL
 Java_org_zeromq_zyre_ZyreEvent__1_1name (JNIEnv *env, jclass c, jlong self)
 {
     char *name_ = (char *) zyre_event_name ((zyre_event_t *) self);
-    jstring return_string_ = (*env)->NewStringUTF (env, name_);
-    return return_string_;
+    jstring string = (*env)->NewStringUTF (env, name_);
+    return string;
 }
 
 JNIEXPORT jstring JNICALL
 Java_org_zeromq_zyre_ZyreEvent__1_1address (JNIEnv *env, jclass c, jlong self)
 {
     char *address_ = (char *) zyre_event_address ((zyre_event_t *) self);
-    jstring return_string_ = (*env)->NewStringUTF (env, address_);
-    return return_string_;
+    jstring string = (*env)->NewStringUTF (env, address_);
+    return string;
 }
 
 JNIEXPORT jlong JNICALL
@@ -66,17 +66,17 @@ Java_org_zeromq_zyre_ZyreEvent__1_1header (JNIEnv *env, jclass c, jlong self, js
 {
     char *name_ = (char *) (*env)->GetStringUTFChars (env, name, NULL);
     char *header_ = (char *) zyre_event_header ((zyre_event_t *) self, name_);
-    jstring return_string_ = (*env)->NewStringUTF (env, header_);
+    jstring string = (*env)->NewStringUTF (env, header_);
     (*env)->ReleaseStringUTFChars (env, name, name_);
-    return return_string_;
+    return string;
 }
 
 JNIEXPORT jstring JNICALL
 Java_org_zeromq_zyre_ZyreEvent__1_1group (JNIEnv *env, jclass c, jlong self)
 {
     char *group_ = (char *) zyre_event_group ((zyre_event_t *) self);
-    jstring return_string_ = (*env)->NewStringUTF (env, group_);
-    return return_string_;
+    jstring string = (*env)->NewStringUTF (env, group_);
+    return string;
 }
 
 JNIEXPORT jlong JNICALL

--- a/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
+++ b/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
@@ -249,6 +249,13 @@ public class Zyre implements AutoCloseable{
         return new Zsock (__socket (self));
     }
     /*
+    Print zyre node information to stdout
+    */
+    native static void __print (long self);
+    public void print () {
+        __print (self);
+    }
+    /*
     Return the Zyre version for run-time API detection
     */
     native static void __version (int major, int minor, int patch);

--- a/bindings/python/zyre.py
+++ b/bindings/python/zyre.py
@@ -103,6 +103,8 @@ lib.zyre_peer_header_value.restype = POINTER(c_char)
 lib.zyre_peer_header_value.argtypes = [zyre_p, c_char_p, c_char_p]
 lib.zyre_socket.restype = czmq.zsock_p
 lib.zyre_socket.argtypes = [zyre_p]
+lib.zyre_print.restype = None
+lib.zyre_print.argtypes = [zyre_p]
 lib.zyre_version.restype = None
 lib.zyre_version.argtypes = [POINTER(c_int), POINTER(c_int), POINTER(c_int)]
 lib.zyre_test.restype = None
@@ -269,6 +271,10 @@ Returns null if peer or key doesn't exits."""
     def socket(self):
         """Return socket for talking to the Zyre node, for polling"""
         return czmq.Zsock(lib.zyre_socket(self._as_parameter_), False)
+
+    def print(self):
+        """Print zyre node information to stdout"""
+        return lib.zyre_print(self._as_parameter_)
 
     @staticmethod
     def version(major, minor, patch):

--- a/bindings/qml/src/QmlZyre.cpp
+++ b/bindings/qml/src/QmlZyre.cpp
@@ -193,6 +193,12 @@ zsock_t *QmlZyre::socket () {
     return zyre_socket (self);
 };
 
+///
+//  Print zyre node information to stdout
+void QmlZyre::print () {
+    zyre_print (self);
+};
+
 
 QObject* QmlZyre::qmlAttachedProperties(QObject* object) {
     return new QmlZyreAttached(object);

--- a/bindings/qml/src/QmlZyre.h
+++ b/bindings/qml/src/QmlZyre.h
@@ -131,6 +131,9 @@ public slots:
 
     //  Return socket for talking to the Zyre node, for polling
     zsock_t *socket ();
+
+    //  Print zyre node information to stdout
+    void print ();
 };
 
 class QmlZyreAttached : public QObject

--- a/bindings/qt/src/qzyre.cpp
+++ b/bindings/qt/src/qzyre.cpp
@@ -267,6 +267,14 @@ QZsock * QZyre::socket ()
 }
 
 ///
+//  Print zyre node information to stdout
+void QZyre::print ()
+{
+    zyre_print (self);
+    
+}
+
+///
 //  Return the Zyre version for run-time API detection
 void QZyre::version (int *major, int *minor, int *patch)
 {

--- a/bindings/ruby/lib/zyre/ffi.rb
+++ b/bindings/ruby/lib/zyre/ffi.rb
@@ -65,6 +65,7 @@ module Zyre
       attach_function :zyre_peer_address, [:pointer, :string], :pointer, **opts
       attach_function :zyre_peer_header_value, [:pointer, :string, :string], :pointer, **opts
       attach_function :zyre_socket, [:pointer], :pointer, **opts
+      attach_function :zyre_print, [:pointer], :void, **opts
       attach_function :zyre_version, [:pointer, :pointer, :pointer], :void, **opts
       attach_function :zyre_test, [:bool], :void, **opts
 

--- a/bindings/ruby/lib/zyre/ffi/zyre.rb
+++ b/bindings/ruby/lib/zyre/ffi/zyre.rb
@@ -320,6 +320,14 @@ module Zyre
         result
       end
 
+      # Print zyre node information to stdout
+      def print()
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::Zyre::FFI.zyre_print(self_p)
+        result
+      end
+
       # Return the Zyre version for run-time API detection
       def self.version(major, minor, patch)
         result = ::Zyre::FFI.zyre_version(major, minor, patch)

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -171,6 +171,10 @@ ZYRE_EXPORT char *
 ZYRE_EXPORT zsock_t *
     zyre_socket (zyre_t *self);
 
+//  Print zyre node information to stdout
+ZYRE_EXPORT void
+    zyre_print (zyre_t *self);
+
 //  Return the Zyre version for run-time API detection
 ZYRE_EXPORT void
     zyre_version (int *major, int *minor, int *patch);


### PR DESCRIPTION
Solution: add this to api/zyre.xml; since zproject/5f2bad, print,
new, and destroy are not added automatically to the class.