### PR TITLE
Problem: Zyre traps and hides Ctrl-C

### DIFF
--- a/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
+++ b/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
@@ -14,6 +14,8 @@ JNIEXPORT jlong JNICALL
 Java_org_zeromq_zyre_Zyre__1_1new (JNIEnv *env, jclass c, jstring name)
 {
     char *name_ = (char *) (*env)->GetStringUTFChars (env, name, NULL);
+    //  Disable CZMQ signal handling; allow Java to deal with it
+    zsys_handler_set (NULL);
     jlong new_ = (jlong) zyre_new (name_);
     (*env)->ReleaseStringUTFChars (env, name, name_);
     return new_;

--- a/bindings/jni/src/main/c/org_zeromq_zyre_ZyreEvent.c
+++ b/bindings/jni/src/main/c/org_zeromq_zyre_ZyreEvent.c
@@ -13,6 +13,8 @@
 JNIEXPORT jlong JNICALL
 Java_org_zeromq_zyre_ZyreEvent__1_1new (JNIEnv *env, jclass c, jlong node)
 {
+    //  Disable CZMQ signal handling; allow Java to deal with it
+    zsys_handler_set (NULL);
     jlong new_ = (jlong) zyre_event_new ((zyre_t *) node);
     return new_;
 }


### PR DESCRIPTION
Solution: disable CZMQ's signal handling.

Note: this solution may not be valid; it still needs testing. The
usual technique in CZMQ apps is to trap SIGINT and then provide a
global (zsys_interrupted) that applications can check. Further, to
interrupt any blocking calls (recv) and return null.

I think we need to expose these two features to language bindings
via a new class in CZMQ.