### PR TITLE
Problem: zyre_event_print was dropped from API

### DIFF
--- a/api/zyre_event.xml
+++ b/api/zyre_event.xml
@@ -74,4 +74,8 @@
         Returns the incoming message payload (currently one frame)
         <return type = "zmsg" />
     </method>
+
+    <method name = "print">
+        Print event to zsys log
+    </method>
 </class>

--- a/include/zyre_event.h
+++ b/include/zyre_event.h
@@ -78,6 +78,10 @@ ZYRE_EXPORT const char *
 ZYRE_EXPORT zmsg_t *
     zyre_event_msg (zyre_event_t *self);
 
+//  Print event to zsys log
+ZYRE_EXPORT void
+    zyre_event_print (zyre_event_t *self);
+
 //  Self test of this class.
 ZYRE_EXPORT void
     zyre_event_test (bool verbose);

--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -137,56 +137,58 @@ zyre_event_log_pair (const char *key, void *item, void *argument)
     return 0;
 }
 
+//  --------------------------------------------------------------------------
+//  Print event to zsys log
+
 void
 zyre_event_print (zyre_event_t *self)
 {
     zsys_info ("zyre_event:");
     zsys_info (" - from name=%s uuid=%s", zyre_event_name(self), zyre_event_sender(self));
 
-    switch (self->type)
-    {
-    case ZYRE_EVENT_ENTER:
-        zsys_info (" - type=ENTER");
-        zsys_info (" - headers=%zu:", zhash_size (self->headers));
-        zhash_foreach (self->headers, (zhash_foreach_fn *) zyre_event_log_pair, self);
-        zsys_info (" - address=%s", zyre_event_address(self));
-        break;
+    switch (self->type) {
+        case ZYRE_EVENT_ENTER:
+            zsys_info (" - type=ENTER");
+            zsys_info (" - headers=%zu:", zhash_size (self->headers));
+            zhash_foreach (self->headers, (zhash_foreach_fn *) zyre_event_log_pair, self);
+            zsys_info (" - address=%s", zyre_event_address(self));
+            break;
 
-    case ZYRE_EVENT_EXIT:
-        zsys_info (" - type=EXIT");
-        break;
+        case ZYRE_EVENT_EXIT:
+            zsys_info (" - type=EXIT");
+            break;
 
-    case ZYRE_EVENT_STOP:
-        zsys_info (" - type=STOP");
-        break;
+        case ZYRE_EVENT_STOP:
+            zsys_info (" - type=STOP");
+            break;
 
-    case ZYRE_EVENT_JOIN:
-        zsys_info (" - type=JOIN");
-        zsys_info (" - group=%s", zyre_event_group(self));
-        break;
+        case ZYRE_EVENT_JOIN:
+            zsys_info (" - type=JOIN");
+            zsys_info (" - group=%s", zyre_event_group(self));
+            break;
 
-    case ZYRE_EVENT_LEAVE:
-        zsys_info (" - type=LEAVE");
-        zsys_info (" - group=%s", zyre_event_group(self));
-        break;
+        case ZYRE_EVENT_LEAVE:
+            zsys_info (" - type=LEAVE");
+            zsys_info (" - group=%s", zyre_event_group(self));
+            break;
 
-    case ZYRE_EVENT_SHOUT:
-        zsys_info (" - type=SHOUT");
-        zsys_info (" - message:");
-        zmsg_print (self->msg);
-        break;
+        case ZYRE_EVENT_SHOUT:
+            zsys_info (" - type=SHOUT");
+            zsys_info (" - message:");
+            zmsg_print (self->msg);
+            break;
 
-    case ZYRE_EVENT_WHISPER:
-        zsys_info (" - type=WHISPER");
-        zsys_info (" - message:");
-        zmsg_print (self->msg);
-        break;
-    case ZYRE_EVENT_EVASIVE:
-	zsys_info (" - type=EVASIVE");
-	break;
-    default:
-        zsys_info (" - type=UNKNOWN");
-        break;
+        case ZYRE_EVENT_WHISPER:
+            zsys_info (" - type=WHISPER");
+            zsys_info (" - message:");
+            zmsg_print (self->msg);
+            break;
+        case ZYRE_EVENT_EVASIVE:
+            zsys_info (" - type=EVASIVE");
+            break;
+        default:
+            zsys_info (" - type=UNKNOWN");
+            break;
     }
 }
 


### PR DESCRIPTION
As zproject no longer defines this by default in all classes.

Solution: define it explicitly.

Fixes #375