### PR TITLE
Problem: Android build is too slow

### DIFF
--- a/builds/android/build.sh
+++ b/builds/android/build.sh
@@ -59,8 +59,8 @@ fi
     export LIBTOOL_EXTRA_LDFLAGS='-avoid-version'
 
     (cd "${cache}/zyre" && ./autogen.sh \
-        && ./configure "${ANDROID_BUILD_OPTS[@]}" \
-        && make \
+        && ./configure "${ANDROID_BUILD_OPTS[@]}" --without-documentation \
+        && make -j 4 \
         && make install) || exit 1
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -219,20 +219,29 @@ zyre_on_android="no"
 # Host specific checks
 AC_CANONICAL_HOST
 
-# Determine whether or not documentation should be built and installed.
-zyre_build_doc="yes"
-zyre_install_man="yes"
+# Allow user to disable doc build
+AC_ARG_WITH([documentation], [AS_HELP_STRING([--without-documentation],
+    [disable documentation build even if asciidoc and xmlto are present [default=no]])])
 
-# Check for asciidoc and xmlto and don't build the docs if these are not installed.
-AC_CHECK_PROG(zyre_have_asciidoc, asciidoc, yes, no)
-AC_CHECK_PROG(zyre_have_xmlto, xmlto, yes, no)
-if test "x$zyre_have_asciidoc" = "xno" -o "x$zyre_have_xmlto" = "xno"; then
+if test "x$with_documentation" = "xno"; then
     zyre_build_doc="no"
-    # Tarballs built with 'make dist' ship with prebuilt documentation.
-    if ! test -f doc/zyre.7; then
-        zyre_install_man="no"
-        AC_MSG_WARN([You are building an unreleased version of ZYRE and asciidoc or xmlto are not installed.])
-        AC_MSG_WARN([Documentation will not be built and manual pages will not be installed.])
+    zyre_install_man="no"
+else
+    # Determine whether or not documentation should be built and installed.
+    zyre_build_doc="yes"
+    zyre_install_man="yes"
+
+    # Check for asciidoc and xmlto and don't build the docs if these are not installed.
+    AC_CHECK_PROG(zyre_have_asciidoc, asciidoc, yes, no)
+    AC_CHECK_PROG(zyre_have_xmlto, xmlto, yes, no)
+    if test "x$zyre_have_asciidoc" = "xno" -o "x$zyre_have_xmlto" = "xno"; then
+        zyre_build_doc="no"
+        # Tarballs built with 'make dist' ship with prebuilt documentation.
+        if ! test -f doc/zyre.7; then
+            zyre_install_man="no"
+            AC_MSG_WARN([You are building an unreleased version of ZYRE and asciidoc or xmlto are not installed.])
+            AC_MSG_WARN([Documentation will not be built and manual pages will not be installed.])
+        fi
     fi
 fi
 AC_MSG_CHECKING([whether to build documentation])


### PR DESCRIPTION
Solution: use parallel make (-j 4) and don't build man pages.

Via zproject.