### PR TITLE
Problem: Travis CI runs tests for dependencies

### DIFF
--- a/ci_build.sh
+++ b/ci_build.sh
@@ -16,13 +16,13 @@ if [ $BUILD_TYPE == "default" ]; then
 
     # Clone and build dependencies
     git clone --depth 1 https://github.com/jedisct1/libsodium libsodium
-    ( cd libsodium && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make check && make install ) || exit 1
+    ( cd libsodium && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make install ) || exit 1
 
     git clone --depth 1 https://github.com/zeromq/libzmq libzmq
-    ( cd libzmq && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make check && make install ) || exit 1
+    ( cd libzmq && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make install ) || exit 1
 
     git clone --depth 1 https://github.com/zeromq/czmq czmq
-    ( cd czmq && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make check && make install ) || exit 1
+    ( cd czmq && ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make install ) || exit 1
 
     # Build and check this project
     ( ./autogen.sh && ./configure "${CONFIG_OPTS[@]}" && make -j4 && make check && make memcheck && make install ) || exit 1


### PR DESCRIPTION
Solution: do not run make check for dependencies in ci_build.sh, as
they are already ran in their own CI and waste time. Already fixed in
Zproject.