### PR TITLE
Problem: zyre travis build fails due to corrupt git cmd

### DIFF
--- a/bindings/python/zyre/_zyre_ctypes.py
+++ b/bindings/python/zyre/_zyre_ctypes.py
@@ -142,6 +142,18 @@ messages it is sending or receiving will be discarded.
         if self.allow_destruct:
             lib.zyre_destroy(byref(self._as_parameter_))
 
+    def __eq__(self, other):
+        if type(other) == type(self):
+            return other.c_address() == self.c_address()
+        elif type(other) == c_void_p:
+            return other.value == self.c_address()
+
+    def c_address(self):
+        """
+        Return the address of the object pointer in c.  Useful for comparison.
+        """
+        return addressof(self._as_parameter_.contents)
+
     def __bool__(self):
         "Determine whether the object is valid by converting to boolean" # Python 3
         return self._as_parameter_.__bool__()
@@ -427,6 +439,18 @@ data (WHISPER, SHOUT).
         """
         if self.allow_destruct:
             lib.zyre_event_destroy(byref(self._as_parameter_))
+
+    def __eq__(self, other):
+        if type(other) == type(self):
+            return other.c_address() == self.c_address()
+        elif type(other) == c_void_p:
+            return other.value == self.c_address()
+
+    def c_address(self):
+        """
+        Return the address of the object pointer in c.  Useful for comparison.
+        """
+        return addressof(self._as_parameter_.contents)
 
     def __bool__(self):
         "Determine whether the object is valid by converting to boolean" # Python 3

--- a/bindings/ruby/lib/zyre/ffi.rb
+++ b/bindings/ruby/lib/zyre/ffi.rb
@@ -42,7 +42,7 @@ module Zyre
         attach_function :zyre_new, [:string], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function new() can't be used through " +
+          warn "The function zyre_new() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -50,7 +50,7 @@ module Zyre
         attach_function :zyre_destroy, [:pointer], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function destroy() can't be used through " +
+          warn "The function zyre_destroy() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -58,7 +58,7 @@ module Zyre
         attach_function :zyre_uuid, [:pointer], :string, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function uuid() can't be used through " +
+          warn "The function zyre_uuid() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -66,7 +66,7 @@ module Zyre
         attach_function :zyre_name, [:pointer], :string, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function name() can't be used through " +
+          warn "The function zyre_name() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -74,7 +74,7 @@ module Zyre
         attach_function :zyre_set_header, [:pointer, :string, :string, :varargs], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function set_header() can't be used through " +
+          warn "The function zyre_set_header() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -82,7 +82,7 @@ module Zyre
         attach_function :zyre_set_verbose, [:pointer], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function set_verbose() can't be used through " +
+          warn "The function zyre_set_verbose() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -90,7 +90,7 @@ module Zyre
         attach_function :zyre_set_port, [:pointer, :int], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function set_port() can't be used through " +
+          warn "The function zyre_set_port() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -98,7 +98,7 @@ module Zyre
         attach_function :zyre_set_interval, [:pointer, :size_t], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function set_interval() can't be used through " +
+          warn "The function zyre_set_interval() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -106,7 +106,7 @@ module Zyre
         attach_function :zyre_set_interface, [:pointer, :string], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function set_interface() can't be used through " +
+          warn "The function zyre_set_interface() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -114,7 +114,7 @@ module Zyre
         attach_function :zyre_set_endpoint, [:pointer, :string, :varargs], :int, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function set_endpoint() can't be used through " +
+          warn "The function zyre_set_endpoint() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -122,7 +122,7 @@ module Zyre
         attach_function :zyre_gossip_bind, [:pointer, :string, :varargs], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function gossip_bind() can't be used through " +
+          warn "The function zyre_gossip_bind() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -130,7 +130,7 @@ module Zyre
         attach_function :zyre_gossip_connect, [:pointer, :string, :varargs], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function gossip_connect() can't be used through " +
+          warn "The function zyre_gossip_connect() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -138,7 +138,7 @@ module Zyre
         attach_function :zyre_start, [:pointer], :int, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function start() can't be used through " +
+          warn "The function zyre_start() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -146,7 +146,7 @@ module Zyre
         attach_function :zyre_stop, [:pointer], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function stop() can't be used through " +
+          warn "The function zyre_stop() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -154,7 +154,7 @@ module Zyre
         attach_function :zyre_join, [:pointer, :string], :int, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function join() can't be used through " +
+          warn "The function zyre_join() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -162,7 +162,7 @@ module Zyre
         attach_function :zyre_leave, [:pointer, :string], :int, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function leave() can't be used through " +
+          warn "The function zyre_leave() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -170,7 +170,7 @@ module Zyre
         attach_function :zyre_recv, [:pointer], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function recv() can't be used through " +
+          warn "The function zyre_recv() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -178,7 +178,7 @@ module Zyre
         attach_function :zyre_whisper, [:pointer, :string, :pointer], :int, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function whisper() can't be used through " +
+          warn "The function zyre_whisper() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -186,7 +186,7 @@ module Zyre
         attach_function :zyre_shout, [:pointer, :string, :pointer], :int, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function shout() can't be used through " +
+          warn "The function zyre_shout() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -194,7 +194,7 @@ module Zyre
         attach_function :zyre_whispers, [:pointer, :string, :string, :varargs], :int, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function whispers() can't be used through " +
+          warn "The function zyre_whispers() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -202,7 +202,7 @@ module Zyre
         attach_function :zyre_shouts, [:pointer, :string, :string, :varargs], :int, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function shouts() can't be used through " +
+          warn "The function zyre_shouts() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -210,7 +210,7 @@ module Zyre
         attach_function :zyre_peers, [:pointer], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function peers() can't be used through " +
+          warn "The function zyre_peers() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -218,7 +218,7 @@ module Zyre
         attach_function :zyre_own_groups, [:pointer], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function own_groups() can't be used through " +
+          warn "The function zyre_own_groups() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -226,7 +226,7 @@ module Zyre
         attach_function :zyre_peer_groups, [:pointer], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function peer_groups() can't be used through " +
+          warn "The function zyre_peer_groups() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -234,7 +234,7 @@ module Zyre
         attach_function :zyre_peer_address, [:pointer, :string], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function peer_address() can't be used through " +
+          warn "The function zyre_peer_address() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -242,7 +242,7 @@ module Zyre
         attach_function :zyre_peer_header_value, [:pointer, :string, :string], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function peer_header_value() can't be used through " +
+          warn "The function zyre_peer_header_value() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -250,7 +250,7 @@ module Zyre
         attach_function :zyre_socket, [:pointer], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function socket() can't be used through " +
+          warn "The function zyre_socket() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -258,7 +258,7 @@ module Zyre
         attach_function :zyre_print, [:pointer], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function print() can't be used through " +
+          warn "The function zyre_print() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -266,7 +266,7 @@ module Zyre
         attach_function :zyre_version, [:pointer, :pointer, :pointer], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function version() can't be used through " +
+          warn "The function zyre_version() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -274,7 +274,7 @@ module Zyre
         attach_function :zyre_test, [:bool], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function test() can't be used through " +
+          warn "The function zyre_test() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -296,7 +296,7 @@ module Zyre
         attach_function :zyre_event_new, [:pointer], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function new() can't be used through " +
+          warn "The function zyre_event_new() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -304,7 +304,7 @@ module Zyre
         attach_function :zyre_event_destroy, [:pointer], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function destroy() can't be used through " +
+          warn "The function zyre_event_destroy() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -312,7 +312,7 @@ module Zyre
         attach_function :zyre_event_type, [:pointer], :zyre event_type, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function type() can't be used through " +
+          warn "The function zyre_event_type() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -320,7 +320,7 @@ module Zyre
         attach_function :zyre_event_sender, [:pointer], :string, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function sender() can't be used through " +
+          warn "The function zyre_event_sender() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -328,7 +328,7 @@ module Zyre
         attach_function :zyre_event_name, [:pointer], :string, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function name() can't be used through " +
+          warn "The function zyre_event_name() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -336,7 +336,7 @@ module Zyre
         attach_function :zyre_event_address, [:pointer], :string, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function address() can't be used through " +
+          warn "The function zyre_event_address() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -344,7 +344,7 @@ module Zyre
         attach_function :zyre_event_headers, [:pointer], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function headers() can't be used through " +
+          warn "The function zyre_event_headers() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -352,7 +352,7 @@ module Zyre
         attach_function :zyre_event_header, [:pointer, :string], :string, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function header() can't be used through " +
+          warn "The function zyre_event_header() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -360,7 +360,7 @@ module Zyre
         attach_function :zyre_event_group, [:pointer], :string, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function group() can't be used through " +
+          warn "The function zyre_event_group() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -368,7 +368,7 @@ module Zyre
         attach_function :zyre_event_msg, [:pointer], :pointer, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function msg() can't be used through " +
+          warn "The function zyre_event_msg() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -376,7 +376,7 @@ module Zyre
         attach_function :zyre_event_print, [:pointer], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function print() can't be used through " +
+          warn "The function zyre_event_print() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end
@@ -384,7 +384,7 @@ module Zyre
         attach_function :zyre_event_test, [:bool], :void, **opts
       rescue ::FFI::NotFoundError
         if $VERBOSE || $DEBUG
-          warn "The function test() can't be used through " +
+          warn "The function zyre_event_test() can't be used through " +
                "this Ruby binding because it's not available."
         end
       end

--- a/builds/android/ci_build.sh
+++ b/builds/android/ci_build.sh
@@ -31,7 +31,7 @@ export TOOLCHAIN_HOST="arm-linux-androideabi"
 export TOOLCHAIN_ARCH="arm"
 
 export LIBSODIUM_ROOT="/tmp/libsodium"
-git clone --quiet --depth 1 https://github.com/jedisct1/libsodium $LIBSODIUM_ROOT
+git clone --quiet --depth 1 -b stable https://github.com/jedisct1/libsodium $LIBSODIUM_ROOT
 
 export LIBZMQ_ROOT="/tmp/libzmq"
 git clone --quiet --depth 1 https://github.com/zeromq/libzmq $LIBZMQ_ROOT

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -23,25 +23,25 @@ if [ "$BUILD_TYPE" == "default" ]; then
     CONFIG_OPTS+=("--quiet")
 
     # Clone and build dependencies
-    git clone --quiet --depth 1 https://github.com/jedisct1/libsodium libsodium
-    git --no-pager log -oneline -n1
+    git clone --quiet --depth 1 -b stable https://github.com/jedisct1/libsodium libsodium
     cd libsodium
+    git --no-pager log --oneline -n1
     ./autogen.sh 2> /dev/null
     ./configure "${CONFIG_OPTS[@]}"
     make -j4
     make install
     cd ..
     git clone --quiet --depth 1 https://github.com/zeromq/libzmq libzmq
-    git --no-pager log -oneline -n1
     cd libzmq
+    git --no-pager log --oneline -n1
     ./autogen.sh 2> /dev/null
     ./configure "${CONFIG_OPTS[@]}"
     make -j4
     make install
     cd ..
     git clone --quiet --depth 1 https://github.com/zeromq/czmq czmq
-    git --no-pager log -oneline -n1
     cd czmq
+    git --no-pager log --oneline -n1
     ./autogen.sh 2> /dev/null
     ./configure "${CONFIG_OPTS[@]}"
     make -j4

--- a/doc/mkman
+++ b/doc/mkman
@@ -33,7 +33,7 @@ sub pull {
         while (<SOURCE>) {
             if (/$tag/) {
                 while (<SOURCE>) {
-                    last if /\@discuss/ || /\@end/ || /\@ignore/;
+                    last if /\@discuss/ || /\@end/;
                     $_ = "    $_" if $opts eq "code";
                     s/^    // if $opts eq "left";
                     $_ = "    $_" if $opts eq "test";

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -57,7 +57,7 @@ ZYRE_EXPORT const char *
 //  Set node header; these are provided to other nodes during discovery
 //  and come in each ENTER message.                                    
 ZYRE_EXPORT void
-    zyre_set_header (zyre_t *self, const char *name, const char *format, ...);
+    zyre_set_header (zyre_t *self, const char *name, const char *format, ...) CHECK_PRINTF (3);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Set verbose mode; this tells the node to log all traffic as well as 
@@ -95,7 +95,7 @@ ZYRE_EXPORT void
 //  that is meaningful to remote as well as local nodes). Returns 0 if       
 //  the bind was successful, else -1.                                        
 ZYRE_EXPORT int
-    zyre_set_endpoint (zyre_t *self, const char *format, ...);
+    zyre_set_endpoint (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Set-up gossip discovery of other nodes. At least one node in the cluster
@@ -103,14 +103,14 @@ ZYRE_EXPORT int
 //  it. Note that gossip endpoints are completely distinct from Zyre node   
 //  endpoints, and should not overlap (they can use the same transport).    
 ZYRE_EXPORT void
-    zyre_gossip_bind (zyre_t *self, const char *format, ...);
+    zyre_gossip_bind (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Set-up gossip discovery of other nodes. A node may connect to multiple
 //  other nodes, for redundancy paths. For details of the gossip network  
 //  design, see the CZMQ zgossip class.                                   
 ZYRE_EXPORT void
-    zyre_gossip_connect (zyre_t *self, const char *format, ...);
+    zyre_gossip_connect (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Start node, after setting header values. When you start a node it
@@ -159,12 +159,12 @@ ZYRE_EXPORT int
 //  *** Draft method, for development use, may change without warning ***
 //  Send formatted string to a single peer specified as UUID string
 ZYRE_EXPORT int
-    zyre_whispers (zyre_t *self, const char *peer, const char *format, ...);
+    zyre_whispers (zyre_t *self, const char *peer, const char *format, ...) CHECK_PRINTF (3);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Send formatted string to a named group
 ZYRE_EXPORT int
-    zyre_shouts (zyre_t *self, const char *group, const char *format, ...);
+    zyre_shouts (zyre_t *self, const char *group, const char *format, ...) CHECK_PRINTF (3);
 
 //  *** Draft method, for development use, may change without warning ***
 //  Return zlist of current peer ids.
@@ -218,19 +218,6 @@ ZYRE_EXPORT void
     zyre_test (bool verbose);
 
 #endif // ZYRE_BUILD_DRAFT_API
-//  @ignore
-void
-    zyre_set_header (zyre_t *self, const char *name, const char *format, ...) CHECK_PRINTF (3);
-int
-    zyre_set_endpoint (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
-void
-    zyre_gossip_bind (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
-void
-    zyre_gossip_connect (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
-int
-    zyre_whispers (zyre_t *self, const char *peer, const char *format, ...) CHECK_PRINTF (3);
-int
-    zyre_shouts (zyre_t *self, const char *group, const char *format, ...) CHECK_PRINTF (3);
 //  @end
 
 


### PR DESCRIPTION
Solution: use latest zproject which fixes this issue.

This commit includes other minimal enhancements from zproject has well.