### PR TITLE
Problem: Electron test code could be simpler

### DIFF
--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -1,3 +1,17 @@
+# Node.js binding
+
+## Quick Start
+
+```
+mkdir -p $HOME/temp
+cd $HOME/temp
+git clone https://github.com/zeromq/zyre
+cd zyre/bindings/nodejs
+./build.sh
+```
+
+
+
 Problem: can't use Zyre from node.js
 
 Solution: start on binding for Zyre

--- a/bindings/nodejs/tests/index.html
+++ b/bindings/nodejs/tests/index.html
@@ -1,23 +1,13 @@
 <h1>Hello World!</h1>
 
 <script>
-     var remote = require('electron').remote;     
+var remote = require ('electron').remote;
+console.log (remote.getGlobal ('sharedObj').zyre_name);
 
-     // show initial value from main process (in dev console)
-     console.log(remote.getGlobal('sharedObj').prop1);     
+var ipcRenderer = require ('electron').ipcRenderer;
+ipcRenderer.send ('hello');
 
-     // change value of global prop1
-     var zyrename = remote.getGlobal('sharedObj').prop1;     
-
-     // show changed value in main process (in stdout, as a proof it was changed)
-     var ipcRenderer = require('electron').ipcRenderer;     
-     ipcRenderer.send('show-prop1');                       
-
-     // show changed value in renderer process (in dev console)
-     console.log(remote.getGlobal('sharedObj').prop1);
-</script>
-
-<script>
-document.write('<p>zyre.name: ' + zyrename + '</p>');
-document.write('<p>electron.version: ' + process.versions.node + '</p>')
+document.write ('<p>zyre.name: ' + remote.getGlobal ('sharedObj').zyre_name + '</p>');
+document.write ('<p>electron.version: ' + process.versions.node + '</p>')
+document.write ('<p>V8 version: ' + process.versions.v8 + '</p>')
 </script>

--- a/bindings/nodejs/tests/main.js
+++ b/bindings/nodejs/tests/main.js
@@ -1,3 +1,5 @@
+//  Hello World test for Zyre in Electron
+
 'use strict';
 
 const electron = require ('electron');
@@ -7,16 +9,11 @@ const BrowserWindow = electron.BrowserWindow;
 var mainWindow = null;
 var zyre = null;
 
-var ipcMain = require('electron').ipcMain;
+var ipcMain = require ('electron').ipcMain;
 
-global.sharedObj = {prop1: "hello3"};
-
-ipcMain.on('show-prop1', function(event) {
-  console.log(global.sharedObj.prop1);
+ipcMain.on ('hello', function (event) {
+    console.log ("Hello, World");
 });
-
-
-console.log(process.versions)
 
 app.on ('window-all-closed', function () {
     if (process.platform != 'darwin') {
@@ -25,15 +22,16 @@ app.on ('window-all-closed', function () {
 });
 
 app.on ('ready', function () {
+    console.log (process.versions);
+
     var ZyreBinding = require ('zyre');
     var zyre = new ZyreBinding.Zyre ();
-    var zyrename = zyre.name ();
-    console.log ('Node name is: ' + zyrename + ' EOL');
-    global.sharedObj = {prop1: zyrename};
+
+    console.log ('Node name is: ' + zyre.name () + ' EOL');
+    global.sharedObj = { zyre_name: zyre.name () };
 
     mainWindow = new BrowserWindow ({ width:800, height:600 });
     mainWindow.loadURL ('file://' + __dirname + '/index.html');
-    mainWindow.webContents.openDevTools ();
 
     mainWindow.on ('closed', function () {
         zyre.destroy ();


### PR DESCRIPTION
Solution: remove passing of zyre node name via IPC, it's confusing
as we actually pass it via a global variable.