### PR TITLE
Problem: nodejs: gyp can't find include files properly

### DIFF
--- a/bindings/nodejs/binding.gyp
+++ b/bindings/nodejs/binding.gyp
@@ -6,7 +6,8 @@
             "binding.cc"
         ],
         "variables": {
-            "BUILD_ROOT": "<!(echo $BUILD_ROOT)"
+            #   Do at start while PRODUCT_DIR is accurate
+            "BUILD_ROOT": "<(PRODUCT_DIR)"
         },
         "include_dirs": [
             "<!(node -e \"require('nan')\")",


### PR DESCRIPTION
Solution: use PRODUCT_DIR variable, at start before gyp starts
wandering all over the place (PRODUCT_DIR varies depending where
you use it.)