### PR TITLE
problem: shout sends group-name as message

### DIFF
--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -159,7 +159,7 @@ class Zyre: public Nan::ObjectWrap {
         &&  info [1]->IsString ()) {
             Zyre *zyre = Nan::ObjectWrap::Unwrap <Zyre> (info.Holder ());
             Nan::Utf8String group (info [0].As<String>());
-            Nan::Utf8String string (info [0].As<String>());
+            Nan::Utf8String string (info [1].As<String>());
             zmsg_t *msg = zmsg_new ();
             zmsg_pushstr (msg, *string);
             zyre_shout (zyre->self, *group, &msg);


### PR DESCRIPTION
Solution: send the actual message instead of the group name