### PR TITLE
Problem: integer truncation warnings on Windows

### DIFF
--- a/src/zre_msg.c
+++ b/src/zre_msg.c
@@ -30,7 +30,7 @@
 @end
 */
 
-#include "zyre_classes.h"
+#include "../include/zyre.h"
 #include "../include/zre_msg.h"
 
 //  Structure of our class
@@ -71,7 +71,7 @@ struct _zre_msg_t {
 
 //  Put a 1-byte number to the frame
 #define PUT_NUMBER1(host) { \
-    *(byte *) self->needle = (host); \
+    *(byte *) self->needle = (byte) (host); \
     self->needle++; \
 }
 


### PR DESCRIPTION
Solution: fixed in zproto and regenerated here.