### PR TITLE
Problem: NodeJS binding uses wrong (default) linkage

### DIFF
--- a/bindings/nodejs/binding.gyp
+++ b/bindings/nodejs/binding.gyp
@@ -16,6 +16,11 @@
           '../../../libzmq/include',
           '../../include'
       ],
+      'defines': [
+        'ZMQ_STATIC',
+        'CZMQ_STATIC',
+        'ZYRE_STATIC'
+       ],
       'dependencies': [
           '../../builds/gyp/project.gyp:libzyre'
       ]


### PR DESCRIPTION
Solution: specify all _STATIC macros explicitly.