### PR TITLE
Problem: ZYRE not using latest ZPROJECT gsls

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# disables auto CRLF conversion for all files; create the file correctly and it will be allright
+* -text

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,0 +1,5 @@
+zyre (1.1.0) UNRELEASED; urgency=low
+
+  * Initial packaging.
+
+ -- zyre Developers <zeromq-dev@lists.zeromq.org>  Wed, 31 Dec 2014 00:00:00 +0000

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,0 +1,14 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: zyre
+
+Files: *
+Copyright: 2015- zyre Developers <zeromq-dev@lists.zeromq.org>
+License: zyre_license
+ Copyright (c) the Contributors as noted in the AUTHORS file.           
+                                                                        
+ This file is part of Zyre, an open-source framework for proximity-based
+ peer-to-peer applications -- See http://zyre.org.                      
+                                                                        
+ This Source Code Form is subject to the terms of the Mozilla Public    
+ License, v. 2.0. If a copy of the MPL was not distributed with this    
+ file, You can obtain one at http://mozilla.org/MPL/2.0/.               

--- a/packaging/debian/libzyre1.install
+++ b/packaging/debian/libzyre1.install
@@ -1,1 +1,1 @@
-debian/tmp/usr/lib/*/libzyre.so.*
+usr/lib/*/libzyre.so.*


### PR DESCRIPTION
Solution: Regenerated Zyre using zproject/tstgenbld.sh
For details, see https://github.com/zeromq/zproject/pull/587