### PR TITLE
problem: zproject doesn't generate Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,9 @@ builds/android/prefix/
 
 # Python bindings
 *.pyc
+
+# vagrant
+.vagrant
+
+# CLion
+.idea

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -66,9 +66,6 @@ cd ..
 
 cd /vagrant
 ./autogen.sh && ./configure && make && make check
-
-echo 'running self test...'
-src/zyre_selftest
 SCRIPT
 
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,91 @@
+#e -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# This will setup a clean Ubuntu1404 LTS env with a python virtualenv called "pyre" for testing
+
+$script = <<SCRIPT
+apt-get update
+add-apt-repository ppa:fkrull/deadsnakes-python2.7
+apt-get update
+apt-get install -y python-pip python-dev git htop virtualenvwrapper python2.7 python-virtualenv python-support cython \
+git-all build-essential libtool pkg-config autotools-dev autoconf automake cmake uuid-dev libpcre3-dev valgrind \
+libffi-dev
+
+# only execute this next line if interested in updating the man pages as well (adds to build time):
+# sudo apt-get install -y asciidoc
+
+cd /vagrant
+if [ ! -d gs1 ]; then
+    git clone https://github.com/imatix/gsl.git
+fi
+cd gsl/src
+make
+sudo make install
+
+cd /vagrant
+if [ ! -d zproject ]; then 
+    git clone https://github.com/zeromq/zproject.git
+fi
+cd zproject
+./autogen.sh
+./configure
+make
+sudo make install
+
+cd /vagrant
+if [ ! -d libsodium ]; then
+    git clone --depth 1 -b stable https://github.com/jedisct1/libsodium.git
+fi
+cd libsodium
+./autogen.sh && ./configure && make && make check
+sudo make install
+sudo ldconfig
+cd ..
+
+if [ ! -d libzmq ]; then
+    git clone git://github.com/zeromq/libzmq.git
+fi
+cd libzmq
+./autogen.sh
+# do not specify "--with-libsodium" if you prefer to use internal tweetnacl
+# security implementation (recommended for development)
+./configure --with-libsodium && make && make check
+sudo make install
+sudo ldconfig
+cd ..
+
+if [ ! -d czmq ]; then
+    git clone git://github.com/zeromq/czmq.git
+fi
+cd czmq
+./autogen.sh && ./configure && make && make check
+sudo make install
+sudo ldconfig
+sudo python setup.py install
+cd ..
+
+cd /vagrant
+./autogen.sh && ./configure && make && make check
+
+echo 'running self test...'
+src/zyre_selftest
+SCRIPT
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+VAGRANTFILE_LOCAL = 'Vagrantfile.local'
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = 'ubuntu/trusty64'
+  config.vm.provision "shell", inline: $script
+  config.vm.network "public_network"
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--cpus", "2", "--ioapic", "on", "--memory", "512" ]
+  end
+
+  if File.file?(VAGRANTFILE_LOCAL)
+    external = File.read VAGRANTFILE_LOCAL
+    eval external
+  end
+end


### PR DESCRIPTION
[vagrant](https://www.vagrantup.com/docs/why-vagrant/) takes the ubuntu instructions in the readme and enables developers to spin up a virtualbox instance (similar to dockerfile) with all the deps installed:

```
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'ubuntu/trusty64'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'ubuntu/trusty64' is up to date...
==> default: A newer version of the box 'ubuntu/trusty64' is available! You currently
==> default: have version '20160602.0.0'. The latest is version '20160708.1.0'. Run
==> default: `vagrant box update` to update.
==> default: Setting the name of the VM: zyre_default_1468408915027_50
==> default: Clearing any previously set forwarded ports...
==> default: Fixed port collision for 22 => 2222. Now on port 2200.
==> default: Clearing any previously set network interfaces...
==> default: Available bridged network interfaces:
1) en0: Wi-Fi (AirPort)
2) en1: Thunderbolt 1
3) en2: Thunderbolt 2
4) p2p0
5) awdl0
6) bridge0
==> default: When choosing an interface, it is usually the one that is
==> default: being used to connect to the internet.
    default: Which interface should the network bridge to? 1
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
    default: Adapter 3: bridged
==> default: Forwarding ports...
    default: 22 (guest) => 2200 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2200
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: Configuring and enabling network interfaces...
==> default: Mounting shared folders...
    default: /vagrant => /Users/wes/Development/zyre
==> default: Running provisioner: shell...
    default: Running: inline script
==> default: stdin: is not a tty
==> default: Get:1 http://security.ubuntu.com trusty-security InRelease [65.9 kB]
==> default: Ign http://archive.ubuntu.com trusty InRelease
==> default: Get:2 http://archive.ubuntu.com trusty-updates InRelease [65.9 kB]

....
 
==> default: ============================================================================
==> default: Testsuite summary for zyre 1.1.0
==> default: ============================================================================
==> default: # TOTAL: 0
==> default: # PASS:  0
==> default: # SKIP:  0
==> default: # XFAIL: 0
==> default: # FAIL:  0
==> default: # XPASS: 0
==> default: # ERROR: 0
==> default: ============================================================================
==> default: make[3]: Leaving directory `/vagrant'
==> default: /bin/bash ./libtool --mode=execute ./src/zyre_selftest
==> default: Running zyre selftests...
==> default:  * zyre_peer: OK
==> default:  * zyre_group: OK
==> default:  * zyre_node: OK
==> default:  * zyre: OK
==> default:  * zyre_event: OK
==> default:  * zre_msg: OK
==> default:  * zyre_actor: OK
==> default: Tests passed OK
==> default: make[2]: Leaving directory `/vagrant'
==> default: make[1]: Leaving directory `/vagrant'
```

from their website:

"Vagrant provides easy to configure, reproducible, and portable work environments built on top of industry-standard technology and controlled by a single consistent workflow to help maximize the productivity and flexibility of you and your team.

To achieve its magic, Vagrant stands on the shoulders of giants. Machines are provisioned on top of VirtualBox, VMware, AWS, or any other provider. Then, industry-standard provisioning tools such as shell scripts, Chef, or Puppet, can be used to automatically install and configure software on the machine."