### PR TITLE
problem: vagrantfile config defaults to bridged adapter instead of the default (loopback)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,7 +75,6 @@ VAGRANTFILE_LOCAL = 'Vagrantfile.local'
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = 'ubuntu/trusty64'
   config.vm.provision "shell", inline: $script
-  config.vm.network "public_network"
 
   config.vm.provider :virtualbox do |vb|
     vb.customize ["modifyvm", :id, "--cpus", "2", "--ioapic", "on", "--memory", "512" ]


### PR DESCRIPTION
i made a mistake in https://github.com/zeromq/zyre/pull/472 and left the configuration to a bridged adapter by default, which lands the vm on "your public network" (could be insecure). tried to update the PR, but you guys are too responsive! :)