### PR TITLE
Problem: Using ipv6 zone notation in ipv4 mode

### DIFF
--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -837,7 +837,7 @@ zyre_node_recv_beacon (zyre_node_t *self)
         char endpoint [100];
         const char *iface = zsys_interface ();
 
-        if (iface && !streq (iface, "") && !streq (iface, "*"))
+        if (zsys_ipv6 () && iface && !streq (iface, "") && !streq (iface, "*"))
             sprintf (endpoint, "tcp://%s%%%s:%d", ipaddress, iface, ntohs (beacon.port));
         else
             sprintf (endpoint, "tcp://%s:%d", ipaddress, ntohs (beacon.port));


### PR DESCRIPTION
Solution: Check whether we're in ipv6 mode when using ipv6 notation.