### PR TITLE
Problem: private classes self tests no longer ran

### DIFF
--- a/src/zyre.c
+++ b/src/zyre.c
@@ -738,4 +738,12 @@ zyre_test (bool verbose)
     zyre_destroy (&node2);
     //  @end
     printf ("OK\n");
+
+    // zre_msg, zyre_group, zyre_node and zyre_peer are private classes and
+    // symbols are not exported so the tests can't be run from zyre_selftest,
+    // so run them from here
+    zre_msg_test (verbose);
+    zyre_group_test (verbose);
+    zyre_node_test (verbose);
+    zyre_peer_test (verbose);
 }


### PR DESCRIPTION
Solution: given the private classes symbols are intentionally not
exported, the self test functions cannot be called from the external
zyre_selftest binary.
Call them instead from the main class selftest function.