### PR TITLE
Problems: can't use zpinger with IPv6, zsys_interface/ipv6_address might not be set

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Ishwor Gurung
 Kevin Sapper
 KIU Shueng Chuan
 kn0x
+Luca Boccassi
 Maarten Ditzel
 Mark Marsella
 Martin Vala

--- a/src/zpinger.c
+++ b/src/zpinger.c
@@ -30,6 +30,7 @@ int main (int argc, char *argv [])
 {
     bool verbose = false;
     char *iface = NULL;
+    int ipv6 = 0;
     int argn;
     for (argn = 1; argn < argc; argn++) {
         if (streq (argv [argn], "--help")
@@ -38,6 +39,7 @@ int main (int argc, char *argv [])
             puts ("  --help / -h            this help");
             puts ("  --verbose / -v         verbose test output");
             puts ("  --interface / -i       use this interface");
+            puts ("  --ipv6 / -6            use IPv6");
             return 0;
         }
         if (streq (argv [argn], "--verbose")
@@ -47,11 +49,16 @@ int main (int argc, char *argv [])
         if (streq (argv [argn], "--interface")
         ||  streq (argv [argn], "-i"))
             iface = argv [++argn];
+        else
+        if (streq (argv [argn], "--ipv6")
+        ||  streq (argv [argn], "-6"))
+            ipv6 = 1;
         else {
             printf ("Unknown option: %s\n", argv [argn]);
             return 1;
         }
     }
+    zsys_set_ipv6(ipv6);
     zyre_t *zyre = zyre_new (NULL);
     zsys_info ("Create Zyre node, uuid=%s, name=%s", zyre_uuid (zyre), zyre_name (zyre));
     if (verbose)

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -930,9 +930,11 @@ zyre_node_actor (zsock_t *pipe, void *args)
 
             // Is UDP broadcast interface available?
             if (!streq(hostname, "")) {
-                if (zsys_ipv6())
-                    self->port = zsock_bind(self->inbox, "tcp://%s%%%s:*", zsys_ipv6_address(), zsys_interface());
-                else
+                const char *iface = zsys_interface ();
+                if (zsys_ipv6() && iface && !streq (iface, "") && !streq (iface, "*") && !streq (zsys_ipv6_address (), "")) {
+                    self->port = zsock_bind(self->inbox, "tcp://%s%%%s:*", zsys_ipv6_address (),
+                        iface);
+                } else
                     self->port = zsock_bind(self->inbox, "tcp://%s:*", hostname);
 
                 if (self->port > 0) {


### PR DESCRIPTION
Solutions: see commits 

Note that I'm doing final tests of zbeacon + ipv6, hope to be able to send that to CZMQ soon