### PR TITLE
Fix python bindings for Python 3

### DIFF
--- a/bindings/python/ci_build.sh
+++ b/bindings/python/ci_build.sh
@@ -57,3 +57,4 @@ cp -r czmq/bindings/python/czmq bindings/python/
 
 # Setup environment & run tests
 LD_LIBRARY_PATH=$PWD/tmp/lib python bindings/python/test.py
+LD_LIBRARY_PATH=$PWD/tmp/lib python3 bindings/python/test.py

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -15,12 +15,12 @@ class TestZyre(unittest.TestCase):
         e = ZyreEvent(z1)
         self.assertEquals(e.peer_name(), z2.name())
         self.assertEquals(e.peer_uuid(), z2.uuid())
-        self.assertEquals(e.type(), b'ENTER')
+        self.assertEquals(e.type(), 'ENTER')
 
         e = ZyreEvent(z2)
         self.assertEquals(e.peer_name(), z1.name())
         self.assertEquals(e.peer_uuid(), z1.uuid())
-        self.assertEquals(e.type(), b'ENTER')
+        self.assertEquals(e.type(), 'ENTER')
 
         z1.join('test group')
         z2.join('test group')
@@ -28,23 +28,23 @@ class TestZyre(unittest.TestCase):
         e = ZyreEvent(z1)
         self.assertEquals(e.peer_name(), z2.name())
         self.assertEquals(e.peer_uuid(), z2.uuid())
-        self.assertEquals(e.type(), b'JOIN')
-        self.assertEquals(e.group(), b'test group')
+        self.assertEquals(e.type(), 'JOIN')
+        self.assertEquals(e.group(), 'test group')
 
         e = ZyreEvent(z2)
         self.assertEquals(e.peer_name(), z1.name())
         self.assertEquals(e.peer_uuid(), z1.uuid())
-        self.assertEquals(e.type(), b'JOIN')
-        self.assertEquals(e.group(), b'test group')
+        self.assertEquals(e.type(), 'JOIN')
+        self.assertEquals(e.group(), 'test group')
 
         z1.shouts('test group', "Hello World")
 
         e = ZyreEvent(z2)
         self.assertEquals(e.peer_name(), z1.name())
         self.assertEquals(e.peer_uuid(), z1.uuid())
-        self.assertEquals(e.type(), b'SHOUT')
-        self.assertEquals(e.group(), b'test group')
-        self.assertEquals(e.msg().popstr(), b"Hello World")
+        self.assertEquals(e.type(), 'SHOUT')
+        self.assertEquals(e.group(), 'test group')
+        self.assertEquals(e.msg().popstr(), "Hello World")
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/python/test.py
+++ b/bindings/python/test.py
@@ -3,11 +3,11 @@ from zyre import Zyre, ZyreEvent
 
 class TestZyre(unittest.TestCase):
     def test_all(self):
-        z1 = Zyre('t1')
-        z2 = Zyre('t2')
+        z1 = Zyre(b't1')
+        z2 = Zyre(b't2')
 
-        z1.set_header('test_header', 'test1')
-        z2.set_header('test_header', 'test2')
+        z1.set_header(b'test_header', b'test1')
+        z2.set_header(b'test_header', b'test2')
 
         self.assertEquals(z1.start(), 0)
         self.assertEquals(z2.start(), 0)
@@ -15,36 +15,36 @@ class TestZyre(unittest.TestCase):
         e = ZyreEvent(z1)
         self.assertEquals(e.peer_name(), z2.name())
         self.assertEquals(e.peer_uuid(), z2.uuid())
-        self.assertEquals(e.type(), 'ENTER')
+        self.assertEquals(e.type(), b'ENTER')
 
         e = ZyreEvent(z2)
         self.assertEquals(e.peer_name(), z1.name())
         self.assertEquals(e.peer_uuid(), z1.uuid())
-        self.assertEquals(e.type(), 'ENTER')
+        self.assertEquals(e.type(), b'ENTER')
 
-        z1.join('test group')
-        z2.join('test group')
+        z1.join(b'test group')
+        z2.join(b'test group')
 
         e = ZyreEvent(z1)
         self.assertEquals(e.peer_name(), z2.name())
         self.assertEquals(e.peer_uuid(), z2.uuid())
-        self.assertEquals(e.type(), 'JOIN')
-        self.assertEquals(e.group(), 'test group')
+        self.assertEquals(e.type(), b'JOIN')
+        self.assertEquals(e.group(), b'test group')
 
         e = ZyreEvent(z2)
         self.assertEquals(e.peer_name(), z1.name())
         self.assertEquals(e.peer_uuid(), z1.uuid())
-        self.assertEquals(e.type(), 'JOIN')
-        self.assertEquals(e.group(), 'test group')
+        self.assertEquals(e.type(), b'JOIN')
+        self.assertEquals(e.group(), b'test group')
 
-        z1.shouts('test group', "Hello World")
+        z1.shouts(b'test group', b"Hello World")
 
         e = ZyreEvent(z2)
         self.assertEquals(e.peer_name(), z1.name())
         self.assertEquals(e.peer_uuid(), z1.uuid())
-        self.assertEquals(e.type(), 'SHOUT')
-        self.assertEquals(e.group(), 'test group')
-        self.assertEquals(e.msg().popstr(), "Hello World")
+        self.assertEquals(e.type(), b'SHOUT')
+        self.assertEquals(e.group(), b'test group')
+        self.assertEquals(e.msg().popstr(), b"Hello World")
 
 if __name__ == '__main__':
     unittest.main()

--- a/bindings/python/zyre/_zyre_ctypes.py
+++ b/bindings/python/zyre/_zyre_ctypes.py
@@ -153,8 +153,7 @@ specify NULL, Zyre generates a randomized node name from the UUID.
             self.allow_destruct = args[1] # This is a 'fresh' value, owned by us
         else:
             assert(len(args) == 1)
-            # import ipdb; ipdb.set_trace()
-            self._as_parameter_ = lib.zyre_new(args[0].encode()) # Creation of new raw type
+            self._as_parameter_ = lib.zyre_new(args[0]) # Creation of new raw type
             self.allow_destruct = True
 
     def __del__(self):
@@ -202,7 +201,7 @@ messages it is sending or receiving will be discarded.
         Set node header; these are provided to other nodes during discovery
 and come in each ENTER message.
         """
-        return lib.zyre_set_header(self._as_parameter_, name.encode(), format.encode(), *args)
+        return lib.zyre_set_header(self._as_parameter_, name, format, *args)
 
     def set_verbose(self):
         """
@@ -303,7 +302,7 @@ stopping it.
         Join a named group; after joining a group you can send messages to
 the group and all Zyre nodes in that group will receive them.
         """
-        return lib.zyre_join(self._as_parameter_, group.encode())
+        return lib.zyre_join(self._as_parameter_, group)
 
     def leave(self, group):
         """
@@ -343,7 +342,7 @@ Destroys message after sending
         """
         Send formatted string to a named group
         """
-        return lib.zyre_shouts(self._as_parameter_, group.encode(), format.encode(), *args)
+        return lib.zyre_shouts(self._as_parameter_, group, format, *args)
 
     def peers(self):
         """


### PR DESCRIPTION
Problem: python bindings do not work with Python3

Solution: This fixes running the tests for the Python bindings with Python 3, and asks Travis to also run the test script with `python3`. See commits below.