### PR TITLE
Problem: crash when connecting to IPv4 peer with IPv6 enabled

### DIFF
--- a/src/zyre_group.c
+++ b/src/zyre_group.c
@@ -150,7 +150,7 @@ zyre_group_test (bool verbose)
     zuuid_t *me = zuuid_new ();
     zyre_peer_t *peer = zyre_peer_new (peers, you);
     assert (!zyre_peer_connected (peer));
-    zyre_peer_connect (peer, me, "tcp://127.0.0.1:5552", 30000);
+    assert (!zyre_peer_connect (peer, me, "tcp://127.0.0.1:5552", 30000));
     assert (zyre_peer_connected (peer));
 
     zyre_group_join (group, peer);

--- a/src/zyre_peer.h
+++ b/src/zyre_peer.h
@@ -29,7 +29,7 @@ void
     zyre_peer_destroy (zyre_peer_t **self_p);
 
 //  Connect peer mailbox
-void
+int
     zyre_peer_connect (zyre_peer_t *self, zuuid_t *from, const char *endpoint, uint64_t expired_timeout);
 
 //  Connect peer mailbox


### PR DESCRIPTION
Solution: print a debug message but do not crash and clean up the
peer instead if a connection is impossible