### PR TITLE
Problem: manual markdown anchors cause conflict in github

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,43 +5,39 @@
 <a target="_blank" href="http://webchat.freenode.net?channels=%23zeromq&uio=d4"><img src="https://cloud.githubusercontent.com/assets/493242/14886493/5c660ea2-0d51-11e6-8249-502e6c71e9f2.png" height = "20" /></a>
 [![license](https://img.shields.io/github/license/zeromq/zyre.svg)](https://github.com/zeromq/zyre/blob/master/LICENSE)
 
-<A name="toc1-3" title="Zyre - Local Area Clustering for Peer-to-Peer Applications" />
 # Zyre - Local Area Clustering for Peer-to-Peer Applications
 
 | Linux & MacOSX |
 |:--------------:|
 |[![Build Status](https://travis-ci.org/zeromq/zyre.png?branch=master)](https://travis-ci.org/zeromq/zyre)|
 
-<A name="toc2-8" title="Contents" />
 ## Contents
 
 
-**<a href="#toc2-13">Overview</a>**
+**[Overview](#overview)**
 
-**<a href="#toc3-16">Scope and Goals</a>**
+**[Scope and Goals](#scope-and-goals)**
 
-**<a href="#toc3-45">Ownership and License</a>**
+**[Ownership and License](#ownership-and-license)**
 
-**<a href="#toc2-56">Using Zyre</a>**
+**[Using Zyre](#using-zyre)**
 
-**<a href="#toc3-59">Building on Linux</a>**
+**[Building on Linux](#building-on-linux)**
 
-**<a href="#toc3-135">Building on Windows</a>**
+**[Building on Windows](#building-on-windows)**
 
-**<a href="#toc3-181">Linking with an Application</a>**
+**[Linking with an Application](#linking-with-an-application)**
 
-**<a href="#toc3-188">API Summary</a>**
-*  <a href="#toc4-193">zyre - API wrapping one Zyre node</a>
-*  <a href="#toc4-582">zyre_event - no title found</a>
+**[API Summary](#api-summary)**
+*  [zyre - API wrapping one Zyre node](#zyre---api-wrapping-one-zyre-node)
+*  [zyre_event - no title found](#zyre_event---no-title-found)
 
-**<a href="#toc3-745">Hints to Contributors</a>**
+**[Hints to Contributors](#hints-to-contributors)**
 
-**<a href="#toc3-756">This Document</a>**
+**[This Document](#this-document)**
 
-<A name="toc2-13" title="Overview" />
 ## Overview
 
-<A name="toc3-16" title="Scope and Goals" />
 ### Scope and Goals
 
 Zyre provides reliable group messaging over local area networks. It has these key characteristics:
@@ -70,7 +66,6 @@ Technical details:
 * Optimized for WiFi, using UDP broadcasts for discovery and heartbeating…
 * Offers alternative discovery mechanism (gossip) for Ethernet networks.
 
-<A name="toc3-45" title="Ownership and License" />
 ### Ownership and License
 
 The contributors are listed in AUTHORS. This project uses the MPL v2 license, see LICENSE.
@@ -81,10 +76,8 @@ Zyre uses the [CLASS (C Language Style for Scalabilty)](http://rfc.zeromq.org/sp
 
 To report an issue, use the [Zyre issue tracker](https://github.com/zeromq/zyre/issues) at github.com.
 
-<A name="toc2-56" title="Using Zyre" />
 ## Using Zyre
 
-<A name="toc3-59" title="Building on Linux" />
 ### Building on Linux
 
 To start with, you need at least these packages:
@@ -160,7 +153,6 @@ Test by running the `zpinger` command, from two or more PCs.
 
     zyre\src\.libs\zpinger
 
-<A name="toc3-135" title="Building on Windows" />
 ### Building on Windows
 
 To start with, you need MS Visual Studio (C/C++). The free community edition works well.
@@ -206,19 +198,16 @@ Test by running `zpinger` from two or more PCs:
     zyre\builds\msvc\vs2013\ReleaseDEXE\zpinger.exe
 ```
 
-<A name="toc3-181" title="Linking with an Application" />
 ### Linking with an Application
 
 Include `zyre.h` in your application and link with libzyre. Here is a typical gcc link command:
 
     gcc -lzyre -lczmq -lzmq myapp.c -o myapp
 
-<A name="toc3-188" title="API Summary" />
 ### API Summary
 
 This is the API provided by Zyre 2.x, in alphabetical order.
 
-<A name="toc4-193" title="zyre - API wrapping one Zyre node" />
 #### zyre - API wrapping one Zyre node
 
 Zyre does local area discovery and clustering. A Zyre node broadcasts
@@ -238,7 +227,7 @@ frames provide further values:
     JOIN fromnode name groupname
         a peer has joined a specific group
     LEAVE fromnode name groupname
-        a peer has left a specific group
+        a peer has joined a specific group
     WHISPER fromnode name message
         a peer has sent this node a message
     SHOUT fromnode name groupname message
@@ -258,9 +247,8 @@ Todo: allow multipart contents
 This is the class interface:
 
 ```h
-    //  This API is a draft, and may change without notice.
-    #ifdef ZYRE_BUILD_DRAFT_API
-    //  *** Draft method, for development use, may change without warning ***
+    //  This is a stable class, and may not change except for emergencies. It
+    //  is provided in stable builds.
     //  Constructor, creates a new Zyre node. Note that until you start the
     //  node it is silent and invisible to other nodes on the network.     
     //  The node name is provided to other nodes during discovery. If you  
@@ -268,55 +256,60 @@ This is the class interface:
     ZYRE_EXPORT zyre_t *
         zyre_new (const char *name);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Destructor, destroys a Zyre node. When you destroy a node, any
     //  messages it is sending or receiving will be discarded.        
     ZYRE_EXPORT void
         zyre_destroy (zyre_t **self_p);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return our node UUID string, after successful initialization
     ZYRE_EXPORT const char *
         zyre_uuid (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return our node name, after successful initialization
     ZYRE_EXPORT const char *
         zyre_name (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Set node header; these are provided to other nodes during discovery
     //  and come in each ENTER message.                                    
     ZYRE_EXPORT void
-        zyre_set_header (zyre_t *self, const char *name, const char *format, ...);
+        zyre_set_header (zyre_t *self, const char *name, const char *format, ...) CHECK_PRINTF (3);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Set verbose mode; this tells the node to log all traffic as well as
     //  all major events.                                                  
     ZYRE_EXPORT void
         zyre_set_verbose (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Set UDP beacon discovery port; defaults to 5670, this call overrides
     //  that so you can create independent clusters on the same network, for
     //  e.g. development vs. production. Has no effect after zyre_start().  
     ZYRE_EXPORT void
         zyre_set_port (zyre_t *self, int port_nbr);
     
-    //  *** Draft method, for development use, may change without warning ***
+    //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
+    //  This can be tuned in order to deal with expected network conditions
+    //  and the response time expected by the application. This is tied to 
+    //  the beacon interval and rate of messages received.                 
+    ZYRE_EXPORT void
+        zyre_set_evasive_timeout (zyre_t *self, int interval);
+    
+    //  Set the peer expiration timeout, in milliseconds. Default is 30000.
+    //  This can be tuned in order to deal with expected network conditions
+    //  and the response time expected by the application. This is tied to 
+    //  the beacon interval and rate of messages received.                 
+    ZYRE_EXPORT void
+        zyre_set_expired_timeout (zyre_t *self, int interval);
+    
     //  Set UDP beacon discovery interval, in milliseconds. Default is instant
     //  beacon exploration followed by pinging every 1,000 msecs.             
     ZYRE_EXPORT void
         zyre_set_interval (zyre_t *self, size_t interval);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Set network interface for UDP beacons. If you do not set this, CZMQ will
     //  choose an interface for you. On boxes with several interfaces you should
     //  specify which one you want to use, or strange things can happen.        
     ZYRE_EXPORT void
         zyre_set_interface (zyre_t *self, const char *value);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  By default, Zyre binds to an ephemeral TCP port and broadcasts the local 
     //  host name using UDP beaconing. When you call this method, Zyre will use  
     //  gossip discovery instead of UDP beaconing. You MUST set-up the gossip    
@@ -326,49 +319,42 @@ This is the class interface:
     //  that is meaningful to remote as well as local nodes). Returns 0 if       
     //  the bind was successful, else -1.                                        
     ZYRE_EXPORT int
-        zyre_set_endpoint (zyre_t *self, const char *format, ...);
+        zyre_set_endpoint (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Set-up gossip discovery of other nodes. At least one node in the cluster
     //  must bind to a well-known gossip endpoint, so other nodes can connect to
     //  it. Note that gossip endpoints are completely distinct from Zyre node   
     //  endpoints, and should not overlap (they can use the same transport).    
     ZYRE_EXPORT void
-        zyre_gossip_bind (zyre_t *self, const char *format, ...);
+        zyre_gossip_bind (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Set-up gossip discovery of other nodes. A node may connect to multiple
     //  other nodes, for redundancy paths. For details of the gossip network  
     //  design, see the CZMQ zgossip class.                                   
     ZYRE_EXPORT void
-        zyre_gossip_connect (zyre_t *self, const char *format, ...);
+        zyre_gossip_connect (zyre_t *self, const char *format, ...) CHECK_PRINTF (2);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Start node, after setting header values. When you start a node it
     //  begins discovery and connection. Returns 0 if OK, -1 if it wasn't
     //  possible to start the node.                                      
     ZYRE_EXPORT int
         zyre_start (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Stop node; this signals to other peers that this node will go away.
     //  This is polite; however you can also just destroy the node without 
     //  stopping it.                                                       
     ZYRE_EXPORT void
         zyre_stop (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Join a named group; after joining a group you can send messages to
     //  the group and all Zyre nodes in that group will receive them.     
     ZYRE_EXPORT int
         zyre_join (zyre_t *self, const char *group);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Leave a group
     ZYRE_EXPORT int
         zyre_leave (zyre_t *self, const char *group);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Receive next message from network; the message may be a control
     //  message (ENTER, EXIT, JOIN, LEAVE) or data (WHISPER, SHOUT).   
     //  Returns zmsg_t object, or NULL if interrupted                  
@@ -376,88 +362,74 @@ This is the class interface:
     ZYRE_EXPORT zmsg_t *
         zyre_recv (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Send message to single peer, specified as a UUID string
     //  Destroys message after sending                         
     ZYRE_EXPORT int
         zyre_whisper (zyre_t *self, const char *peer, zmsg_t **msg_p);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Send message to a named group 
     //  Destroys message after sending
     ZYRE_EXPORT int
         zyre_shout (zyre_t *self, const char *group, zmsg_t **msg_p);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Send formatted string to a single peer specified as UUID string
     ZYRE_EXPORT int
-        zyre_whispers (zyre_t *self, const char *peer, const char *format, ...);
+        zyre_whispers (zyre_t *self, const char *peer, const char *format, ...) CHECK_PRINTF (3);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Send formatted string to a named group
     ZYRE_EXPORT int
-        zyre_shouts (zyre_t *self, const char *group, const char *format, ...);
+        zyre_shouts (zyre_t *self, const char *group, const char *format, ...) CHECK_PRINTF (3);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return zlist of current peer ids.
     //  Caller owns return value and must destroy it when done.
     ZYRE_EXPORT zlist_t *
         zyre_peers (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return zlist of current peers of this group.
     //  Caller owns return value and must destroy it when done.
     ZYRE_EXPORT zlist_t *
         zyre_peers_by_group (zyre_t *self, const char *name);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return zlist of currently joined groups.
     //  Caller owns return value and must destroy it when done.
     ZYRE_EXPORT zlist_t *
         zyre_own_groups (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return zlist of groups known through connected peers.
     //  Caller owns return value and must destroy it when done.
     ZYRE_EXPORT zlist_t *
         zyre_peer_groups (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return the endpoint of a connected peer.
     //  Caller owns return value and must destroy it when done.
     ZYRE_EXPORT char *
         zyre_peer_address (zyre_t *self, const char *peer);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return the value of a header of a conected peer.
     //  Returns null if peer or key doesn't exits.      
     //  Caller owns return value and must destroy it when done.
     ZYRE_EXPORT char *
         zyre_peer_header_value (zyre_t *self, const char *peer, const char *name);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return socket for talking to the Zyre node, for polling
     ZYRE_EXPORT zsock_t *
         zyre_socket (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Print zyre node information to stdout
     ZYRE_EXPORT void
         zyre_print (zyre_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return the Zyre version for run-time API detection; returns
     //  major * 10000 + minor * 100 + patch, as a single integer.  
     ZYRE_EXPORT uint64_t
         zyre_version (void);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Self test of this class.
     ZYRE_EXPORT void
         zyre_test (bool verbose);
     
-    #endif // ZYRE_BUILD_DRAFT_API
 ```
+Please add '@interface' section in './../src/zyre.c'.
 
 This is the class self test code:
 
@@ -607,75 +579,65 @@ This is the class self test code:
     zyre_destroy (&node2);
 ```
 
-<A name="toc4-582" title="zyre_event - no title found" />
 #### zyre_event - no title found
 
 This class provides a higher-level API to the zyre_recv call, by doing
 work that you will want to do in many cases, such as unpacking the peer
 headers for each ENTER event received.
 
-Please add @discuss section in ../src/zyre_event.c.
+Please add '@discuss' section in './../src/zyre_event.c'.
 
 This is the class interface:
 
 ```h
-    //  This API is a draft, and may change without notice.
-    #ifdef ZYRE_BUILD_DRAFT_API
-    //  *** Draft method, for development use, may change without warning ***
+    //  This is a stable class, and may not change except for emergencies. It
+    //  is provided in stable builds.
     //  Constructor: receive an event from the zyre node, wraps zyre_recv.
     //  The event may be a control message (ENTER, EXIT, JOIN, LEAVE) or  
     //  data (WHISPER, SHOUT).                                            
     ZYRE_EXPORT zyre_event_t *
         zyre_event_new (zyre_t *node);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Destructor; destroys an event instance
     ZYRE_EXPORT void
         zyre_event_destroy (zyre_event_t **self_p);
     
-    //  *** Draft method, for development use, may change without warning ***
-    //  Returns event type, as printable uppercase string
+    //  Returns event type, as printable uppercase string. Choices are:   
+    //  "ENTER", "EXIT", "JOIN", "LEAVE", "EVASIVE", "WHISPER" and "SHOUT"
+    //  and for the local node: "STOP"                                    
     ZYRE_EXPORT const char *
         zyre_event_type (zyre_event_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return the sending peer's uuid as a string
     ZYRE_EXPORT const char *
         zyre_event_peer_uuid (zyre_event_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return the sending peer's public name as a string
     ZYRE_EXPORT const char *
         zyre_event_peer_name (zyre_event_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Return the sending peer's ipaddress as a string
     ZYRE_EXPORT const char *
         zyre_event_peer_addr (zyre_event_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Returns the event headers, or NULL if there are none
     ZYRE_EXPORT zhash_t *
         zyre_event_headers (zyre_event_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Returns value of a header from the message headers   
     //  obtained by ENTER. Return NULL if no value was found.
     ZYRE_EXPORT const char *
         zyre_event_header (zyre_event_t *self, const char *name);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Returns the group name that a SHOUT event was sent to
     ZYRE_EXPORT const char *
         zyre_event_group (zyre_event_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Returns the incoming message payload; the caller can modify the
     //  message but does not own it and should not destroy it.         
     ZYRE_EXPORT zmsg_t *
         zyre_event_msg (zyre_event_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Returns the incoming message payload, and pass ownership to the   
     //  caller. The caller must destroy the message when finished with it.
     //  After called on the given event, further calls will return NULL.  
@@ -683,18 +645,16 @@ This is the class interface:
     ZYRE_EXPORT zmsg_t *
         zyre_event_get_msg (zyre_event_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Print event to zsys log
     ZYRE_EXPORT void
         zyre_event_print (zyre_event_t *self);
     
-    //  *** Draft method, for development use, may change without warning ***
     //  Self test of this class.
     ZYRE_EXPORT void
         zyre_event_test (bool verbose);
     
-    #endif // ZYRE_BUILD_DRAFT_API
 ```
+Please add '@interface' section in './../src/zyre_event.c'.
 
 This is the class self test code:
 
@@ -770,7 +730,6 @@ This is the class self test code:
 ```
 
 
-<A name="toc3-745" title="Hints to Contributors" />
 ### Hints to Contributors
 
 Zyre is a nice, neat library, and you may not immediately appreciate why. Read the CLASS style guide please, and write your code to make it indistinguishable from the rest of the code in the library. That is the only real criteria for good style: it's invisible.
@@ -781,7 +740,6 @@ Do read your code after you write it and ask, "Can I make this simpler?" We do u
 
 Before opening a pull request read our [contribution guidelines](https://github.com/zeromq/zyre/blob/master/CONTRIBUTING.md). Thanks!
 
-<A name="toc3-756" title="This Document" />
 ### This Document
 
 _This documentation was generated from zyre/README.txt using [Gitdown](https://github.com/zeromq/gitdown)_


### PR DESCRIPTION
Solution: Generate from latest gitdown which uses markdown anchors
instead.