### PR TITLE
Problem: Peers are incorrectly kept alive by UDP beacons after TCP connection has dropped.

### DIFF
--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -856,10 +856,7 @@ zyre_node_recv_beacon (zyre_node_t *self)
         char endpoint [NI_MAXHOST];
         sprintf (endpoint, "tcp://%s:%d", ipaddress, ntohs (beacon.port));
 
-        zyre_peer_t *peer = zyre_node_require_peer (self, uuid, endpoint);
-        if (peer)
-            zyre_peer_refresh (peer, self->evasive_timeout,
-                    self->expired_timeout);
+        zyre_node_require_peer (self, uuid, endpoint);
     }
     else {
         //  Zero port means peer is going away; remove it if

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -607,6 +607,8 @@ zyre_node_require_peer (zyre_node_t *self, zuuid_t *uuid, const char *endpoint)
         zre_msg_set_headers (msg, &headers);
         zyre_peer_send (peer, &msg);
         zre_msg_destroy (&msg);
+        
+        zyre_peer_refresh (peer, self->evasive_timeout, self->expired_timeout);
     }
     return peer;
 }


### PR DESCRIPTION
Solution: Attached commits ensure that peers are only kept alive on messages over the DEALER/ROUTER pair and not the beacons.