### PR TITLE
Problem: project.xml missing license prop, python cffi bindings complain

### DIFF
--- a/project.xml
+++ b/project.xml
@@ -2,6 +2,7 @@
     name = "zyre"
     description = "an open-source framework for proximity-based P2P apps"
     script = "zproject.gsl"
+    license = "MPLv2"
     email = "zeromq-dev@lists.zeromq.org"
     url = "https://github.com/zeromq/zyre"
     repository = "https://github.com/zeromq/zyre"


### PR DESCRIPTION
solution: add license property to project.xml (mirroring czmq/project.xml)

```
...
gsl/4 M: Building Mingw32 build system (mingw32)
gsl/4 M: Building Packaging for NuGet (nuget)
gsl/4 M: Building service for Open Build Service (obs)
gsl/4 M: Building Python binding (python)
gsl/4 M: Building Python CFFI binding (python_cffi)
(zproject_python_cffi.gsl 346) Undefined expression: project.license
```

surprised only python CFFI cares(?) and that it wasn't in there ?