### PR TITLE
from ctypes.util import find_library

### DIFF
--- a/bindings/python_cffi/zyre/build_zyre_cffi.py
+++ b/bindings/python_cffi/zyre/build_zyre_cffi.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import os
 import re
 import sys
+from ctypes.util import find_library
 
 from cffi import FFI
 

--- a/bindings/python_cffi/zyre_cffi.py
+++ b/bindings/python_cffi/zyre_cffi.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 import os
 import re
 import sys
+from ctypes.util import find_library
 
 from pyczmq._cffi import ffi
 

--- a/bindings/python_cffi/zyre_cffi/dlopen.py
+++ b/bindings/python_cffi/zyre_cffi/dlopen.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 import os
 import sys
+from ctypes.util import find_library
 
 import cffi
 ffi = cffi.FFI()


### PR DESCRIPTION
https://github.com/zeromq/zproject/pull/964 (merged)  Contains the ultimate fix

__Problem:__ If we are going to call `find_library()`on line 25 then we must define it first or a NameError could be raised at runtime.

__Solution:__ `from ctypes.util import find_library` https://docs.python.org/3/library/ctypes.html#finding-shared-libraries