### PR TITLE
[WIP] problem: HELLO messages do no contain X-PUBLICKEY header, other debug/test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,6 @@ matrix:
   - env: BUILD_TYPE=valgrind
     os: linux
     dist: trusty
-    sudo: required
     addons:
       apt:
         sources:

--- a/api/zyre.api
+++ b/api/zyre.api
@@ -107,11 +107,6 @@
         <argument name = "zcert" type = "zcert"></argument>
     </method>
 
-    <method name = "beacon set version" state = "draft">
-        Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-        <argument name = "version" type = "string"></argument>
-    </method>
-
     <method name = "gossip bind">
         Set-up gossip discovery of other nodes. At least one node in the cluster
         must bind to a well-known gossip endpoint, so other nodes can connect to

--- a/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
+++ b/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
@@ -115,14 +115,6 @@ Java_org_zeromq_zyre_Zyre__1_1setZcert (JNIEnv *env, jclass c, jlong self, jlong
 }
 
 JNIEXPORT void JNICALL
-Java_org_zeromq_zyre_Zyre__1_1beaconSetVersion (JNIEnv *env, jclass c, jlong self, jstring version)
-{
-    char *version_ = (char *) (*env)->GetStringUTFChars (env, version, NULL);
-    zyre_beacon_set_version ((zyre_t *) (intptr_t) self, version_);
-    (*env)->ReleaseStringUTFChars (env, version, version_);
-}
-
-JNIEXPORT void JNICALL
 Java_org_zeromq_zyre_Zyre__1_1gossipBind (JNIEnv *env, jclass c, jlong self, jstring format)
 {
     char *format_ = (char *) (*env)->GetStringUTFChars (env, format, NULL);

--- a/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
+++ b/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
@@ -148,13 +148,6 @@ public class Zyre implements AutoCloseable{
         __setZcert (self, zcert.self);
     }
     /*
-    Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-    */
-    native static void __beaconSetVersion (long self, String version);
-    public void beaconSetVersion (String version) {
-        __beaconSetVersion (self, version);
-    }
-    /*
     Set-up gossip discovery of other nodes. At least one node in the cluster
     must bind to a well-known gossip endpoint, so other nodes can connect to
     it. Note that gossip endpoints are completely distinct from Zyre node

--- a/bindings/lua_ffi/zyre_ffi.lua
+++ b/bindings/lua_ffi/zyre_ffi.lua
@@ -110,10 +110,6 @@ int
 void
     zyre_set_zcert (zyre_t *self, zcert_t *zcert);
 
-// Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-void
-    zyre_beacon_set_version (zyre_t *self, const char *version);
-
 // Set-up gossip discovery of other nodes. At least one node in the cluster
 // must bind to a well-known gossip endpoint, so other nodes can connect to
 // it. Note that gossip endpoints are completely distinct from Zyre node

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -155,12 +155,6 @@ nothing my_zyre.setZcert (Zcert)
 Apply a azcert to a Zyre node.
 
 ```
-nothing my_zyre.beaconSetVersion (String)
-```
-
-Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-
-```
 nothing my_zyre.gossipBind (String)
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -45,7 +45,6 @@ NAN_MODULE_INIT (Zyre::Init) {
     Nan::SetPrototypeMethod (tpl, "setInterface", _set_interface);
     Nan::SetPrototypeMethod (tpl, "setEndpoint", _set_endpoint);
     Nan::SetPrototypeMethod (tpl, "setZcert", _set_zcert);
-    Nan::SetPrototypeMethod (tpl, "beaconSetVersion", _beacon_set_version);
     Nan::SetPrototypeMethod (tpl, "gossipBind", _gossip_bind);
     Nan::SetPrototypeMethod (tpl, "gossipConnect", _gossip_connect);
     Nan::SetPrototypeMethod (tpl, "gossipConnectCurve", _gossip_connect_curve);
@@ -257,21 +256,6 @@ NAN_METHOD (Zyre::_set_zcert) {
     Zyre *zyre = Nan::ObjectWrap::Unwrap <Zyre> (info.Holder ());
     Zcert *zcert = Nan::ObjectWrap::Unwrap<Zcert>(info [0].As<Object>());
     zyre_set_zcert (zyre->self, zcert->self);
-}
-
-NAN_METHOD (Zyre::_beacon_set_version) {
-    Zyre *zyre = Nan::ObjectWrap::Unwrap <Zyre> (info.Holder ());
-    char *version;
-    if (info [0]->IsUndefined ())
-        return Nan::ThrowTypeError ("method requires a `version`");
-    else
-    if (!info [0]->IsString ())
-        return Nan::ThrowTypeError ("`version` must be a string");
-    else {
-        Nan::Utf8String version_utf8 (info [0].As<String>());
-        version = *version_utf8;
-    }
-    zyre_beacon_set_version (zyre->self, (const char *)version);
 }
 
 NAN_METHOD (Zyre::_gossip_bind) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -54,7 +54,6 @@ class Zyre: public Nan::ObjectWrap {
     static NAN_METHOD (_set_interface);
     static NAN_METHOD (_set_endpoint);
     static NAN_METHOD (_set_zcert);
-    static NAN_METHOD (_beacon_set_version);
     static NAN_METHOD (_gossip_bind);
     static NAN_METHOD (_gossip_connect);
     static NAN_METHOD (_gossip_connect_curve);

--- a/bindings/python/zyre/_zyre_ctypes.py
+++ b/bindings/python/zyre/_zyre_ctypes.py
@@ -94,8 +94,6 @@ lib.zyre_set_endpoint.restype = c_int
 lib.zyre_set_endpoint.argtypes = [zyre_p, c_char_p]
 lib.zyre_set_zcert.restype = None
 lib.zyre_set_zcert.argtypes = [zyre_p, czmq.zcert_p]
-lib.zyre_beacon_set_version.restype = None
-lib.zyre_beacon_set_version.argtypes = [zyre_p, c_char_p]
 lib.zyre_gossip_bind.restype = None
 lib.zyre_gossip_bind.argtypes = [zyre_p, c_char_p]
 lib.zyre_gossip_connect.restype = None
@@ -286,12 +284,6 @@ the bind was successful, else -1.
         Apply a azcert to a Zyre node.
         """
         return lib.zyre_set_zcert(self._as_parameter_, zcert)
-
-    def beacon_set_version(self, version):
-        """
-        Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-        """
-        return lib.zyre_beacon_set_version(self._as_parameter_, version)
 
     def gossip_bind(self, format, *args):
         """

--- a/bindings/python_cffi/zyre_cffi/Zyre.py
+++ b/bindings/python_cffi/zyre_cffi/Zyre.py
@@ -124,12 +124,6 @@ class Zyre(object):
         """
         return libzyre.zyre_set_zcert(self._p, zcert._p)
 
-    def beacon_set_version(self, version):
-        """
-        Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-        """
-        return libzyre.zyre_beacon_set_version(self._p, to_bytes(version))
-
     def gossip_bind(self, format, ):
         """
         Set-up gossip discovery of other nodes. At least one node in the cluster

--- a/bindings/python_cffi/zyre_cffi/_cdefs.inc
+++ b/bindings/python_cffi/zyre_cffi/_cdefs.inc
@@ -98,10 +98,6 @@ int
 void
     zyre_set_zcert (zyre_t *self, zcert_t *zcert);
 
-// Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-void
-    zyre_beacon_set_version (zyre_t *self, const char *version);
-
 // Set-up gossip discovery of other nodes. At least one node in the cluster
 // must bind to a well-known gossip endpoint, so other nodes can connect to
 // it. Note that gossip endpoints are completely distinct from Zyre node

--- a/bindings/python_cffi/zyre_cffi/cdefs.py
+++ b/bindings/python_cffi/zyre_cffi/cdefs.py
@@ -4170,10 +4170,6 @@ int
 void
     zyre_set_zcert (zyre_t *self, zcert_t *zcert);
 
-// Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-void
-    zyre_beacon_set_version (zyre_t *self, const char *version);
-
 // Set-up gossip discovery of other nodes. At least one node in the cluster
 // must bind to a well-known gossip endpoint, so other nodes can connect to
 // it. Note that gossip endpoints are completely distinct from Zyre node

--- a/bindings/qml/src/QmlZyre.cpp
+++ b/bindings/qml/src/QmlZyre.cpp
@@ -103,12 +103,6 @@ void QmlZyre::setZcert (zcert_t *zcert) {
 };
 
 ///
-//  Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-void QmlZyre::beaconSetVersion (const QString &version) {
-    zyre_beacon_set_version (self, version.toUtf8().data());
-};
-
-///
 //  Set-up gossip discovery of other nodes. At least one node in the cluster
 //  must bind to a well-known gossip endpoint, so other nodes can connect to
 //  it. Note that gossip endpoints are completely distinct from Zyre node

--- a/bindings/qml/src/QmlZyre.h
+++ b/bindings/qml/src/QmlZyre.h
@@ -86,9 +86,6 @@ public slots:
     //  Apply a azcert to a Zyre node.
     void setZcert (zcert_t *zcert);
 
-    //  Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-    void beaconSetVersion (const QString &version);
-
     //  Set-up gossip discovery of other nodes. At least one node in the cluster
     //  must bind to a well-known gossip endpoint, so other nodes can connect to
     //  it. Note that gossip endpoints are completely distinct from Zyre node

--- a/bindings/qt/src/qzyre.cpp
+++ b/bindings/qt/src/qzyre.cpp
@@ -152,14 +152,6 @@ void QZyre::setZcert (QZcert *zcert)
 }
 
 ///
-//  Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-void QZyre::beaconSetVersion (const QString &version)
-{
-    zyre_beacon_set_version (self, version.toUtf8().data());
-
-}
-
-///
 //  Set-up gossip discovery of other nodes. At least one node in the cluster
 //  must bind to a well-known gossip endpoint, so other nodes can connect to
 //  it. Note that gossip endpoints are completely distinct from Zyre node

--- a/bindings/ruby/lib/zyre/ffi.rb
+++ b/bindings/ruby/lib/zyre/ffi.rb
@@ -64,17 +64,6 @@ module Zyre
           raise NotImplementedError, "compile zyre with --enable-drafts"
         end
       end
-      begin # DRAFT method
-        attach_function :zyre_beacon_set_version, [:pointer, :string], :void, **opts
-      rescue ::FFI::NotFoundError
-        if $VERBOSE || $DEBUG
-          warn "The DRAFT function zyre_beacon_set_version()" +
-            " is not provided by the installed zyre library."
-        end
-        def self.zyre_beacon_set_version(*)
-          raise NotImplementedError, "compile zyre with --enable-drafts"
-        end
-      end
       attach_function :zyre_gossip_bind, [:pointer, :string, :varargs], :void, **opts
       attach_function :zyre_gossip_connect, [:pointer, :string, :varargs], :void, **opts
       begin # DRAFT method

--- a/bindings/ruby/lib/zyre/ffi/zyre.rb
+++ b/bindings/ruby/lib/zyre/ffi/zyre.rb
@@ -253,17 +253,6 @@ module Zyre
         result
       end
 
-      # Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-      #
-      # @param version [String, #to_s, nil]
-      # @return [void]
-      def beacon_set_version(version)
-        raise DestroyedError unless @ptr
-        self_p = @ptr
-        result = ::Zyre::FFI.zyre_beacon_set_version(self_p, version)
-        result
-      end
-
       # Set-up gossip discovery of other nodes. At least one node in the cluster
       # must bind to a well-known gossip endpoint, so other nodes can connect to
       # it. Note that gossip endpoints are completely distinct from Zyre node

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -221,11 +221,6 @@ ZYRE_EXPORT void
     zyre_set_zcert (zyre_t *self, zcert_t *zcert);
 
 //  *** Draft method, for development use, may change without warning ***
-//  Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-ZYRE_EXPORT void
-    zyre_beacon_set_version (zyre_t *self, const char *version);
-
-//  *** Draft method, for development use, may change without warning ***
 //  Set-up gossip discovery with CURVE enabled.
 ZYRE_EXPORT void
     zyre_gossip_connect_curve (zyre_t *self, const char *public_key, const char *format, ...) CHECK_PRINTF (3);

--- a/src/zyre_classes.h
+++ b/src/zyre_classes.h
@@ -61,11 +61,6 @@ ZYRE_PRIVATE void
     zyre_set_zcert (zyre_t *self, zcert_t *zcert);
 
 //  *** Draft method, defined for internal use only ***
-//  Set the beacon version. Useful when working with ZYREv3 with secure beacons.
-ZYRE_PRIVATE void
-    zyre_beacon_set_version (zyre_t *self, const char *version);
-
-//  *** Draft method, defined for internal use only ***
 //  Set-up gossip discovery with CURVE enabled.
 ZYRE_PRIVATE void
     zyre_gossip_connect_curve (zyre_t *self, const char *public_key, const char *format, ...) CHECK_PRINTF (3);


### PR DESCRIPTION
[note- the linux boxes built / tested ok on travis, but the OSX boxes are queued, feel free to wait until those clear out to merge]

https://travis-ci.org/wesyoung/zyre/builds/275558707

solution: catch and un-wrap HELLO messages to check for public key header when new connection happens (missed in the original PR)

+ updated .travis.yml to NOT use sudo for valgrind testing (see mailing list for more info)
+ cleaned up un-necessariy set_beacon_version function left over in gsl xml
+ regen zproject headers to last working zproject state (recent PR throws errors, zproject travis check will fail until that's cleaned up)
+ cleaned up zyre-curve tests and debugging info (to use `if (verbose)` more
+ added improved ZMQ2|3 detection where ZMQ_CURVE is not defined