### PR TITLE
problem: can't require peer from outside the actor

### DIFF
--- a/api/zyre.api
+++ b/api/zyre.api
@@ -226,6 +226,14 @@
         <return type = "string" fresh = "1" />
     </method>
 
+    <method name = "require peer" state = "draft">
+        Explicitly connect to a peer
+        <argument name = "uuid" type = "string" />
+        <argument name = "endpoint" type = "string" />
+        <argument name = "public_key" type = "string" optional = "1" />
+        <return type = "integer" />
+    </method>
+
     <method name = "socket">
         Return socket for talking to the Zyre node, for polling
         <return type = "zsock" />

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -225,6 +225,11 @@ ZYRE_EXPORT void
 ZYRE_EXPORT void
     zyre_gossip_connect_curve (zyre_t *self, const char *public_key, const char *format, ...) CHECK_PRINTF (3);
 
+//  *** Draft method, for development use, may change without warning ***
+//  Explicitly connect to a peer
+ZYRE_EXPORT int
+    zyre_require_peer (zyre_t *self, const char *uuid, const char *endpoint, const char *public_key);
+
 #endif // ZYRE_BUILD_DRAFT_API
 //  @end
 

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -286,6 +286,15 @@ void zyre_set_zcert(zyre_t *self, zcert_t *zcert)
     zstr_sendx (self->actor, "SET SECRETKEY", zcert_secret_txt(zcert), NULL);
 }
 
+//  Explicitly connect to a peer
+
+int
+zyre_require_peer (zyre_t *self, const char *uuid, const char *endpoint, const char *public_key)
+{
+    assert (self);
+    return zstr_sendx (self->actor, "REQUIRE PEER", uuid, endpoint, public_key, NULL);
+}
+
 //  --------------------------------------------------------------------------
 //  Set-up gossip discovery of other nodes. At least one node in the cluster
 //  must bind to a well-known gossip endpoint, so other nodes can connect to


### PR DESCRIPTION
This enables an external discovery actor to introduce zyre nodes.