### PR TITLE
problem: zyre dump doesn't include peer information

### DIFF
--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -321,9 +321,16 @@ zyre_node_send_peer (const char *key, void *item, void *argument)
 //  Print hash key to log
 
 static int
-zyre_node_log_item (const char *key, void *item, void *argument)
+zyre_node_log_peer (zyre_peer_t *peer)
 {
-    zsys_info ("   - %s", key);
+    zsys_info ("   - uuid=%s name=%s endpoint=%s connected=%s ready=%s sent_seq=%" PRIu16 " want_seq=%"PRIu16,
+        zyre_peer_identity(peer),
+        zyre_peer_name(peer),
+        zyre_peer_endpoint(peer),
+        zyre_peer_connected(peer) ? "yes" : "no",
+        zyre_peer_ready(peer) ? "yes" : "no",
+        zyre_peer_sent_sequence(peer),
+        zyre_peer_want_sequence(peer));
     return 0;
 }
 
@@ -367,7 +374,7 @@ zyre_node_dump (zyre_node_t *self)
     zsys_info (" - peers=%zu:", zhash_size (self->peers));
     for (item = zhash_first (self->peers); item != NULL;
             item = zhash_next (self->peers))
-        zyre_node_log_item (zhash_cursor (self->peers), item, self);
+        zyre_node_log_peer((zyre_peer_t *)item);
 
     zsys_info (" - own groups=%zu:", zlist_size (self->own_groups));
     const char *group = (const char *) zlist_first (self->own_groups);

--- a/src/zyre_peer.c
+++ b/src/zyre_peer.c
@@ -507,6 +507,25 @@ zyre_peer_set_verbose (zyre_peer_t *self, bool verbose)
     self->verbose = verbose;
 }
 
+//  --------------------------------------------------------------------------
+//  Return want_sequence
+
+uint16_t
+zyre_peer_want_sequence (zyre_peer_t *self)
+{
+    assert (self);
+    return self->want_sequence;
+}
+//
+//  --------------------------------------------------------------------------
+//  Return sent_sequence
+
+uint16_t
+zyre_peer_sent_sequence (zyre_peer_t *self)
+{
+    assert (self);
+    return self->sent_sequence;
+}
 
 //  --------------------------------------------------------------------------
 //  Self test of this class

--- a/src/zyre_peer.h
+++ b/src/zyre_peer.h
@@ -112,6 +112,13 @@ bool
 void
     zyre_peer_set_verbose (zyre_peer_t *self, bool verbose);
 
+//  Return want_sequence
+uint16_t
+    zyre_peer_want_sequence (zyre_peer_t *self);
+
+//  Return sent_sequence
+uint16_t
+    zyre_peer_sent_sequence (zyre_peer_t *self);
 
 // private
 #ifdef ZYRE_BUILD_DRAFT_API


### PR DESCRIPTION
When dumping zyre state, include all information from peers including
uuid,name,endpoint,status,and sequence numbers.

This changes the peer lines from

- 2C4C71325429324D62067181111DD4BA
- 6C22F14923E148F41662EDED5B10A27F

to

- uuid=2C4C71325429324D62067181111DD4BA name= endpoint=tcp://192.168.2.20:49152 connected=yes ready=no sent_seq=21 want_seq=0
- uuid=6C22F14923E148F41662EDED5B10A27F name=vm1 endpoint=tcp://192.168.2.187:13000 connected=yes ready=yes sent_seq=326 want_seq=204