### PR TITLE
Problem: assertion fails when requesting endpoint of non-existent peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ This is the class interface:
         zyre_peer_groups (zyre_t *self);
     
     //  Return the endpoint of a connected peer.
+    //  Returns empty string if peer does not exist.
     //  Caller owns return value and must destroy it when done.
     ZYRE_EXPORT char *
         zyre_peer_address (zyre_t *self, const char *peer);

--- a/api/zyre.api
+++ b/api/zyre.api
@@ -219,6 +219,7 @@
 
     <method name = "peer address">
         Return the endpoint of a connected peer.
+        Returns empty string if peer does not exist.
         <argument name = "peer" type = "string" />
         <return type = "string" fresh = "1" />
     </method>

--- a/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
+++ b/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
@@ -282,6 +282,7 @@ public class Zyre implements AutoCloseable{
     }
     /*
     Return the endpoint of a connected peer.
+    Returns empty string if peer does not exist.
     */
     native static String __peerAddress (long self, String peer);
     public String peerAddress (String peer) {

--- a/bindings/lua_ffi/zyre_ffi.lua
+++ b/bindings/lua_ffi/zyre_ffi.lua
@@ -193,6 +193,7 @@ zlist_t *
     zyre_peer_groups (zyre_t *self);
 
 // Return the endpoint of a connected peer.
+// Returns empty string if peer does not exist.
 char *
     zyre_peer_address (zyre_t *self, const char *peer);
 

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -275,6 +275,7 @@ string my_zyre.peerAddress (String)
 ```
 
 Return the endpoint of a connected peer.
+Returns empty string if peer does not exist.
 
 ```
 string my_zyre.peerHeaderValue (String, String)

--- a/bindings/python/zyre/_zyre_ctypes.py
+++ b/bindings/python/zyre/_zyre_ctypes.py
@@ -408,6 +408,7 @@ Destroys message after sending
     def peer_address(self, peer):
         """
         Return the endpoint of a connected peer.
+Returns empty string if peer does not exist.
         """
         return return_fresh_string(lib.zyre_peer_address(self._as_parameter_, peer))
 

--- a/bindings/python_cffi/zyre_cffi/Zyre.py
+++ b/bindings/python_cffi/zyre_cffi/Zyre.py
@@ -240,6 +240,7 @@ class Zyre(object):
     def peer_address(self, peer):
         """
         Return the endpoint of a connected peer.
+        Returns empty string if peer does not exist.
         """
         return utils.lib.zyre_peer_address(self._p, utils.to_bytes(peer))
 

--- a/bindings/python_cffi/zyre_cffi/_cdefs.inc
+++ b/bindings/python_cffi/zyre_cffi/_cdefs.inc
@@ -181,6 +181,7 @@ zlist_t *
     zyre_peer_groups (zyre_t *self);
 
 // Return the endpoint of a connected peer.
+// Returns empty string if peer does not exist.
 char *
     zyre_peer_address (zyre_t *self, const char *peer);
 

--- a/bindings/python_cffi/zyre_cffi/cdefs.py
+++ b/bindings/python_cffi/zyre_cffi/cdefs.py
@@ -4262,6 +4262,7 @@ zlist_t *
     zyre_peer_groups (zyre_t *self);
 
 // Return the endpoint of a connected peer.
+// Returns empty string if peer does not exist.
 char *
     zyre_peer_address (zyre_t *self, const char *peer);
 

--- a/bindings/qml/src/QmlZyre.cpp
+++ b/bindings/qml/src/QmlZyre.cpp
@@ -220,6 +220,7 @@ zlist_t *QmlZyre::peerGroups () {
 
 ///
 //  Return the endpoint of a connected peer.
+//  Returns empty string if peer does not exist.
 QString QmlZyre::peerAddress (const QString &peer) {
     char *retStr_ = zyre_peer_address (self, peer.toUtf8().data());
     QString retQStr_ = QString (retStr_);

--- a/bindings/qml/src/QmlZyre.h
+++ b/bindings/qml/src/QmlZyre.h
@@ -152,6 +152,7 @@ public slots:
     zlist_t *peerGroups ();
 
     //  Return the endpoint of a connected peer.
+    //  Returns empty string if peer does not exist.
     QString peerAddress (const QString &peer);
 
     //  Return the value of a header of a conected peer.

--- a/bindings/qt/src/qzyre.cpp
+++ b/bindings/qt/src/qzyre.cpp
@@ -303,6 +303,7 @@ QZlist * QZyre::peerGroups ()
 
 ///
 //  Return the endpoint of a connected peer.
+//  Returns empty string if peer does not exist.
 QString QZyre::peerAddress (const QString &peer)
 {
     char *retStr_ = zyre_peer_address (self, peer.toUtf8().data());

--- a/bindings/ruby/lib/zyre/ffi/zyre.rb
+++ b/bindings/ruby/lib/zyre/ffi/zyre.rb
@@ -459,6 +459,7 @@ module Zyre
       end
 
       # Return the endpoint of a connected peer.
+      # Returns empty string if peer does not exist.
       #
       # @param peer [String, #to_s, nil]
       # @return [::FFI::AutoPointer]

--- a/doc/zyre.doc
+++ b/doc/zyre.doc
@@ -191,6 +191,7 @@ This is the class interface:
         zyre_peer_groups (zyre_t *self);
     
     //  Return the endpoint of a connected peer.
+    //  Returns empty string if the peer does not exist.
     //  Caller owns return value and must destroy it when done.
     ZYRE_EXPORT char *
         zyre_peer_address (zyre_t *self, const char *peer);

--- a/doc/zyre.txt
+++ b/doc/zyre.txt
@@ -162,6 +162,7 @@ ZYRE_EXPORT zlist_t *
     zyre_peer_groups (zyre_t *self);
 
 //  Return the endpoint of a connected peer.
+//  Returns empty string if the peer does not exist.
 //  Caller owns return value and must destroy it when done.
 ZYRE_EXPORT char *
     zyre_peer_address (zyre_t *self, const char *peer);

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -187,6 +187,7 @@ ZYRE_EXPORT zlist_t *
     zyre_peer_groups (zyre_t *self);
 
 //  Return the endpoint of a connected peer.
+//  Returns empty string if peer does not exist.
 //  Caller owns return value and must destroy it when done.
 ZYRE_EXPORT char *
     zyre_peer_address (zyre_t *self, const char *peer);

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -529,7 +529,8 @@ zyre_peers_by_group (zyre_t *self, const char *group)
 
 
 //  --------------------------------------------------------------------------
-//  Return the endpoint of a connected peer. Caller owns the string.
+//  Return the endpoint of a connected peer. Returns empty string if
+//  the peer does not exist. Caller owns the string.
 
 char *
 zyre_peer_address (zyre_t *self, const char *peer)

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -684,8 +684,10 @@ zyre_node_recv_api (zyre_node_t *self)
     if (streq (command, "PEER ENDPOINT")) {
         char *uuid = zmsg_popstr (request);
         zyre_peer_t *peer = (zyre_peer_t *) zhash_lookup (self->peers, uuid);
-        assert (peer);
-        zsock_send (self->pipe, "s", zyre_peer_endpoint (peer));
+        if (peer)
+            zsock_send (self->pipe, "s", zyre_peer_endpoint (peer));
+        else
+            zsock_send (self->pipe, "s", "");
         zstr_free (&uuid);
     }
     else


### PR DESCRIPTION
Solution: return empty string for endpoint if peer does not exist