### PR TITLE
problem: zyre doesn't support a way to provide an alternative (public) endpoint (eg: in NAT situations)

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -94,6 +94,11 @@ void
 int
     zyre_set_endpoint (zyre_t *self, const char *format, ...);
 
+// Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+// if you're advertising an endpoint behind a NAT.
+void
+    zyre_set_advertised_endpoint (zyre_t *self, const char *value);
+
 // Apply a azcert to a Zyre node.
 void
     zyre_set_zcert (zyre_t *self, zcert_t *zcert);

--- a/api/zyre.api
+++ b/api/zyre.api
@@ -102,6 +102,12 @@
         <return type = "integer" />
     </method>
 
+    <method name = "set advertised endpoint" state = "draft">
+        Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+        if you're advertising an endpoint behind a NAT.
+        <argument name = "value" type = "string" />
+    </method>
+
     <method name = "set zcert" state = "draft">
         Apply a azcert to a Zyre node.
         <argument name = "zcert" type = "zcert"></argument>

--- a/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
+++ b/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
@@ -109,6 +109,14 @@ Java_org_zeromq_zyre_Zyre__1_1setEndpoint (JNIEnv *env, jclass c, jlong self, js
 }
 
 JNIEXPORT void JNICALL
+Java_org_zeromq_zyre_Zyre__1_1setAdvertisedEndpoint (JNIEnv *env, jclass c, jlong self, jstring value)
+{
+    char *value_ = (char *) (*env)->GetStringUTFChars (env, value, NULL);
+    zyre_set_advertised_endpoint ((zyre_t *) (intptr_t) self, value_);
+    (*env)->ReleaseStringUTFChars (env, value, value_);
+}
+
+JNIEXPORT void JNICALL
 Java_org_zeromq_zyre_Zyre__1_1setZcert (JNIEnv *env, jclass c, jlong self, jlong zcert)
 {
     zyre_set_zcert ((zyre_t *) (intptr_t) self, (zcert_t *) (intptr_t) zcert);

--- a/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
+++ b/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
@@ -141,6 +141,14 @@ public class Zyre implements AutoCloseable{
         return __setEndpoint (self, format);
     }
     /*
+    Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+    if you're advertising an endpoint behind a NAT.
+    */
+    native static void __setAdvertisedEndpoint (long self, String value);
+    public void setAdvertisedEndpoint (String value) {
+        __setAdvertisedEndpoint (self, value);
+    }
+    /*
     Apply a azcert to a Zyre node.
     */
     native static void __setZcert (long self, long zcert);

--- a/bindings/lua_ffi/zyre_ffi.lua
+++ b/bindings/lua_ffi/zyre_ffi.lua
@@ -106,6 +106,11 @@ void
 int
     zyre_set_endpoint (zyre_t *self, const char *format, ...);
 
+// Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+// if you're advertising an endpoint behind a NAT.
+void
+    zyre_set_advertised_endpoint (zyre_t *self, const char *value);
+
 // Apply a azcert to a Zyre node.
 void
     zyre_set_zcert (zyre_t *self, zcert_t *zcert);

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -149,6 +149,13 @@ that is meaningful to remote as well as local nodes). Returns 0 if
 the bind was successful, else -1.
 
 ```
+nothing my_zyre.setAdvertisedEndpoint (String)
+```
+
+Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+if you're advertising an endpoint behind a NAT.
+
+```
 nothing my_zyre.setZcert (Zcert)
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -44,6 +44,7 @@ NAN_MODULE_INIT (Zyre::Init) {
     Nan::SetPrototypeMethod (tpl, "setInterval", _set_interval);
     Nan::SetPrototypeMethod (tpl, "setInterface", _set_interface);
     Nan::SetPrototypeMethod (tpl, "setEndpoint", _set_endpoint);
+    Nan::SetPrototypeMethod (tpl, "setAdvertisedEndpoint", _set_advertised_endpoint);
     Nan::SetPrototypeMethod (tpl, "setZcert", _set_zcert);
     Nan::SetPrototypeMethod (tpl, "setZapDomain", _set_zap_domain);
     Nan::SetPrototypeMethod (tpl, "gossipBind", _gossip_bind);
@@ -267,6 +268,21 @@ NAN_METHOD (Zyre::_set_endpoint) {
          //} //bjornw end
     int result = zyre_set_endpoint (zyre->self, "%s", format);
     info.GetReturnValue ().Set (Nan::New<Number>(result));
+}
+
+NAN_METHOD (Zyre::_set_advertised_endpoint) {
+    Zyre *zyre = Nan::ObjectWrap::Unwrap <Zyre> (info.Holder ());
+    char *value;
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `value`");
+    else
+    if (!info [0]->IsString ())
+        return Nan::ThrowTypeError ("`value` must be a string");
+    //else { // bjornw: remove brackets to keep scope
+    Nan::Utf8String value_utf8 (info [0].As<String>());
+    value = *value_utf8;
+         //} //bjornw end
+    zyre_set_advertised_endpoint (zyre->self, (const char *)value);
 }
 
 NAN_METHOD (Zyre::_set_zcert) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -53,6 +53,7 @@ class Zyre: public Nan::ObjectWrap {
     static NAN_METHOD (_set_interval);
     static NAN_METHOD (_set_interface);
     static NAN_METHOD (_set_endpoint);
+    static NAN_METHOD (_set_advertised_endpoint);
     static NAN_METHOD (_set_zcert);
     static NAN_METHOD (_set_zap_domain);
     static NAN_METHOD (_gossip_bind);

--- a/bindings/python/zyre/_zyre_ctypes.py
+++ b/bindings/python/zyre/_zyre_ctypes.py
@@ -92,6 +92,8 @@ lib.zyre_set_interface.restype = None
 lib.zyre_set_interface.argtypes = [zyre_p, c_char_p]
 lib.zyre_set_endpoint.restype = c_int
 lib.zyre_set_endpoint.argtypes = [zyre_p, c_char_p]
+lib.zyre_set_advertised_endpoint.restype = None
+lib.zyre_set_advertised_endpoint.argtypes = [zyre_p, c_char_p]
 lib.zyre_set_zcert.restype = None
 lib.zyre_set_zcert.argtypes = [zyre_p, czmq.zcert_p]
 lib.zyre_set_zap_domain.restype = None
@@ -282,6 +284,13 @@ that is meaningful to remote as well as local nodes). Returns 0 if
 the bind was successful, else -1.
         """
         return lib.zyre_set_endpoint(self._as_parameter_, format, *args)
+
+    def set_advertised_endpoint(self, value):
+        """
+        Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+if you're advertising an endpoint behind a NAT.
+        """
+        return lib.zyre_set_advertised_endpoint(self._as_parameter_, value)
 
     def set_zcert(self, zcert):
         """

--- a/bindings/python_cffi/zyre_cffi/Zyre.py
+++ b/bindings/python_cffi/zyre_cffi/Zyre.py
@@ -115,6 +115,13 @@ class Zyre(object):
         """
         return utils.lib.zyre_set_endpoint(self._p, format, )
 
+    def set_advertised_endpoint(self, value):
+        """
+        Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+        if you're advertising an endpoint behind a NAT.
+        """
+        utils.lib.zyre_set_advertised_endpoint(self._p, utils.to_bytes(value))
+
     def set_zcert(self, zcert):
         """
         Apply a azcert to a Zyre node.

--- a/bindings/python_cffi/zyre_cffi/cdefs.py
+++ b/bindings/python_cffi/zyre_cffi/cdefs.py
@@ -2345,12 +2345,6 @@ void
 void
     zproc_set_verbose (zproc_t *self, bool verbose);
 
-// Returns true if the process received a SIGINT or SIGTERM signal.
-// It is good practice to use this method to exit any infinite loop
-// processing messages.
-bool
-    zproc_interrupted (void);
-
 // Self test of this class.
 void
     zproc_test (bool verbose);
@@ -3507,6 +3501,18 @@ void
 void
     zsys_catch_interrupts (void);
 
+// Check if default interrupt handler of Ctrl-C or SIGTERM was called.
+// Does not work if ZSYS_SIGHANDLER is false and code does not call
+// set interrupted on signal.
+bool
+    zsys_is_interrupted (void);
+
+// Set interrupted flag. This is done by default signal handler, however
+// this can be handy for language bindings or cases without default
+// signal handler.
+void
+    zsys_set_interrupted (void);
+
 // Return 1 if file exists, else zero
 bool
     zsys_file_exists (const char *filename);
@@ -4082,6 +4088,11 @@ void
 // the bind was successful, else -1.
 int
     zyre_set_endpoint (zyre_t *self, const char *format, ...);
+
+// Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+// if you're advertising an endpoint behind a NAT.
+void
+    zyre_set_advertised_endpoint (zyre_t *self, const char *value);
 
 // Apply a azcert to a Zyre node.
 void

--- a/bindings/qml/src/QmlZyre.cpp
+++ b/bindings/qml/src/QmlZyre.cpp
@@ -97,6 +97,13 @@ int QmlZyre::setEndpoint (const QString &format) {
 };
 
 ///
+//  Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+//  if you're advertising an endpoint behind a NAT.
+void QmlZyre::setAdvertisedEndpoint (const QString &value) {
+    zyre_set_advertised_endpoint (self, value.toUtf8().data());
+};
+
+///
 //  Apply a azcert to a Zyre node.
 void QmlZyre::setZcert (zcert_t *zcert) {
     zyre_set_zcert (self, zcert);

--- a/bindings/qml/src/QmlZyre.h
+++ b/bindings/qml/src/QmlZyre.h
@@ -83,6 +83,10 @@ public slots:
     //  the bind was successful, else -1.
     int setEndpoint (const QString &format);
 
+    //  Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+    //  if you're advertising an endpoint behind a NAT.
+    void setAdvertisedEndpoint (const QString &value);
+
     //  Apply a azcert to a Zyre node.
     void setZcert (zcert_t *zcert);
 

--- a/bindings/qt/src/qzyre.cpp
+++ b/bindings/qt/src/qzyre.cpp
@@ -144,6 +144,15 @@ int QZyre::setEndpoint (const QString &param)
 }
 
 ///
+//  Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+//  if you're advertising an endpoint behind a NAT.
+void QZyre::setAdvertisedEndpoint (const QString &value)
+{
+    zyre_set_advertised_endpoint (self, value.toUtf8().data());
+
+}
+
+///
 //  Apply a azcert to a Zyre node.
 void QZyre::setZcert (QZcert *zcert)
 {

--- a/bindings/ruby/lib/zyre/ffi.rb
+++ b/bindings/ruby/lib/zyre/ffi.rb
@@ -66,6 +66,7 @@ module Zyre
       attach_function :zyre_set_interval, [:pointer, :size_t], :void, **opts
       attach_function :zyre_set_interface, [:pointer, :string], :void, **opts
       attach_function :zyre_set_endpoint, [:pointer, :string, :varargs], :int, **opts
+      attach_function :zyre_set_advertised_endpoint, [:pointer, :string], :void, **opts
       attach_function :zyre_set_zcert, [:pointer, :pointer], :void, **opts
       attach_function :zyre_set_zap_domain, [:pointer, :string], :void, **opts
       attach_function :zyre_gossip_bind, [:pointer, :string, :varargs], :void, **opts

--- a/bindings/ruby/lib/zyre/ffi/zyre.rb
+++ b/bindings/ruby/lib/zyre/ffi/zyre.rb
@@ -242,6 +242,18 @@ module Zyre
         result
       end
 
+      # Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+      # if you're advertising an endpoint behind a NAT.
+      #
+      # @param value [String, #to_s, nil]
+      # @return [void]
+      def set_advertised_endpoint(value)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::Zyre::FFI.zyre_set_advertised_endpoint(self_p, value)
+        result
+      end
+
       # Apply a azcert to a Zyre node.
       #
       # @param zcert [::FFI::Pointer, #to_ptr]

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -217,6 +217,12 @@ ZYRE_EXPORT void
 
 #ifdef ZYRE_BUILD_DRAFT_API
 //  *** Draft method, for development use, may change without warning ***
+//  Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+//  if you're advertising an endpoint behind a NAT.
+ZYRE_EXPORT void
+    zyre_set_advertised_endpoint (zyre_t *self, const char *value);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Apply a azcert to a Zyre node.
 ZYRE_EXPORT void
     zyre_set_zcert (zyre_t *self, zcert_t *zcert);

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -277,6 +277,16 @@ zyre_set_endpoint (zyre_t *self, const char *format, ...)
     return zsock_wait (self->actor) == 0? 0: -1;
 }
 
+#ifdef ZYRE_BUILD_DRAFT_API
+void
+zyre_set_advertised_endpoint (zyre_t *self, const char *endpoint)
+{
+    assert (self);
+    assert (endpoint);
+    zstr_sendx (self->actor, "SET ADVERTISED ENDPOINT", endpoint, NULL);
+}
+#endif
+
 void zyre_set_zcert(zyre_t *self, zcert_t *zcert)
 {
     assert (zcert);
@@ -943,6 +953,10 @@ zyre_test (bool verbose)
 
         zyre_set_header(node5, "X-PUBLICKEY", "%s", zcert_public_txt(node5_cert));
         zyre_set_header(node6, "X-PUBLICKEY", "%s", zcert_public_txt(node6_cert));
+
+        // TODO- set_advertised_endpoint tests
+//        zyre_set_endpoint(node5, "tcp://127.0.0.1:9001");
+//        zyre_set_advertised_endpoint(node5, "tcp://localhost:9001");
 
         const char *gossip_cert = zcert_public_txt (node5_cert);
 

--- a/src/zyre_classes.h
+++ b/src/zyre_classes.h
@@ -56,6 +56,12 @@ typedef struct _zyre_node_t zyre_node_t;
 #ifndef ZYRE_BUILD_DRAFT_API
 
 //  *** Draft method, defined for internal use only ***
+//  Set an alternative endpoint value when using GOSSIP ONLY. This is useful
+//  if you're advertising an endpoint behind a NAT.
+ZYRE_PRIVATE void
+    zyre_set_advertised_endpoint (zyre_t *self, const char *value);
+
+//  *** Draft method, defined for internal use only ***
 //  Apply a azcert to a Zyre node.
 ZYRE_PRIVATE void
     zyre_set_zcert (zyre_t *self, zcert_t *zcert);


### PR DESCRIPTION
solution: add DRAFT functionality to bind to a local endpoint, while providing an advertised public ip as the endpoint gossip should publish through the mesh (rather than the default private address).

decided to try a more explicit route here instead of trying to do address rewrites (yet), because in certain situations a node may connect out one gateway (eg: it's own NAT) but home on a different public IP (and port it can control). this happens a lot on things like AWS where you may have a node that's not publicly accessible via it's default adapter, which accesses the internet through a NAT gateway- but listens for zyre traffic on a different adapter using a public IP and set of firewall rules that differ from it's management interface.

it's kind of an odd ball case- but also why i want to test being explicit about the advertising and work down into the magic at the application layer rather than trying to be clever in the engine (for now). seems to work OK across two nodes, with the caveat that if the two nodes connecting to the gossip master are behind a NAT of their own (the same public IP), they will connect and talk to the gossip node no problem, but won't be able to connect to each-other (because they're advertising the same external IP). not a deal breaker- just a caveat (more of a design problem i would think, that's probably where you start bridging the two things together with other socket types, etc).
