### PR TITLE
Problem: example for compiling zyre application throws undefined refe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Test by running `zpinger` from two or more PCs:
 
 Include `zyre.h` in your application and link with libzyre. Here is a typical gcc link command:
 
-    gcc -lzyre -lczmq -lzmq myapp.c -o myapp
+    gcc myapp.c -lzyre -lczmq -lzmq -o myapp
 
 ### API Summary
 

--- a/README.txt
+++ b/README.txt
@@ -183,7 +183,7 @@ Test by running `zpinger` from two or more PCs:
 
 Include `zyre.h` in your application and link with libzyre. Here is a typical gcc link command:
 
-    gcc -lzyre -lczmq -lzmq myapp.c -o myapp
+    gcc myapp.c -lzyre -lczmq -lzmq -o myapp
 
 ### API Summary
 


### PR DESCRIPTION
…rence errors

Solution: fix order of linked libraries for gcc example