### PR TITLE
Problem: zyre_new API change breaks backward compat

### DIFF
--- a/src/zyre.c
+++ b/src/zyre.c
@@ -74,8 +74,6 @@ struct _zyre_t {
 zyre_t *
 zyre_new (const char *name)
 {
-    assert(name);
-
     zyre_t *self = (zyre_t *) zmalloc (sizeof (zyre_t));
     assert (self);
 


### PR DESCRIPTION
Solution: don't assert if the name is NULL, it's allowed and checked
later anyway

Fixes https://github.com/zeromq/zyre/issues/588