### PR TITLE
Added API to set Ephemeral TCP port for beacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ This is the class interface:
     ZYRE_EXPORT void
         zyre_set_port (zyre_t *self, int port_nbr);
     
+    // Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+    // This call overrides this, to bypass some firewall issues when ports are
+    // random. Has no effect after zyre_start().
+    ZYRE_EXPORT void
+        zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+    
     //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
     //  This can be tuned in order to deal with expected network conditions
     //  and the response time expected by the application. This is tied to 

--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -58,6 +58,12 @@ void
 void
     zyre_set_port (zyre_t *self, int port_nbr);
 
+// Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+// This call overrides this, to bypass some firewall issues when ports are
+// random. Has no effect after zyre_start().
+void
+    zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+
 // Set the peer evasiveness timeout, in milliseconds. Default is 5000.
 // This can be tuned in order to deal with expected network conditions
 // and the response time expected by the application. This is tied to

--- a/api/zyre.api
+++ b/api/zyre.api
@@ -60,6 +60,13 @@
         <argument name = "port nbr" type = "integer" />
     </method>
 
+    <method name = "set ephemeral port" state = "draft">
+        Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+        This call overrides this, to bypass some firewall issues when ports are
+        random. Has no effect after zyre_start().
+        <argument name = "port nbr" type = "integer" />
+    </method>
+
     <method name = "set evasive timeout">
         Set the peer evasiveness timeout, in milliseconds. Default is 5000.
         This can be tuned in order to deal with expected network conditions

--- a/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
+++ b/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
@@ -74,6 +74,12 @@ Java_org_zeromq_zyre_Zyre__1_1setPort (JNIEnv *env, jclass c, jlong self, jint p
 }
 
 JNIEXPORT void JNICALL
+Java_org_zeromq_zyre_Zyre__1_1setEphemeralPort (JNIEnv *env, jclass c, jlong self, jint port_nbr)
+{
+    zyre_set_ephemeral_port ((zyre_t *) (intptr_t) self, (int) port_nbr);
+}
+
+JNIEXPORT void JNICALL
 Java_org_zeromq_zyre_Zyre__1_1setEvasiveTimeout (JNIEnv *env, jclass c, jlong self, jint interval)
 {
     zyre_set_evasive_timeout ((zyre_t *) (intptr_t) self, (int) interval);

--- a/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
+++ b/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
@@ -90,6 +90,15 @@ public class Zyre implements AutoCloseable{
         __setPort (self, portNbr);
     }
     /*
+    Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+    This call overrides this, to bypass some firewall issues when ports are
+    random. Has no effect after zyre_start().
+    */
+    native static void __setEphemeralPort (long self, int portNbr);
+    public void setEphemeralPort (int portNbr) {
+        __setEphemeralPort (self, portNbr);
+    }
+    /*
     Set the peer evasiveness timeout, in milliseconds. Default is 5000.
     This can be tuned in order to deal with expected network conditions
     and the response time expected by the application. This is tied to

--- a/bindings/lua_ffi/zyre_ffi.lua
+++ b/bindings/lua_ffi/zyre_ffi.lua
@@ -70,6 +70,12 @@ void
 void
     zyre_set_port (zyre_t *self, int port_nbr);
 
+// Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+// This call overrides this, to bypass some firewall issues when ports are
+// random. Has no effect after zyre_start().
+void
+    zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+
 // Set the peer evasiveness timeout, in milliseconds. Default is 5000.
 // This can be tuned in order to deal with expected network conditions
 // and the response time expected by the application. This is tied to

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -103,6 +103,14 @@ that so you can create independent clusters on the same network, for
 e.g. development vs. production. Has no effect after zyre_start().
 
 ```
+nothing my_zyre.setEphemeralPort (Number)
+```
+
+Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+This call overrides this, to bypass some firewall issues when ports are
+random. Has no effect after zyre_start().
+
+```
 nothing my_zyre.setEvasiveTimeout (Number)
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -39,6 +39,7 @@ NAN_MODULE_INIT (Zyre::Init) {
     Nan::SetPrototypeMethod (tpl, "setHeader", _set_header);
     Nan::SetPrototypeMethod (tpl, "setVerbose", _set_verbose);
     Nan::SetPrototypeMethod (tpl, "setPort", _set_port);
+    Nan::SetPrototypeMethod (tpl, "setEphemeralPort", _set_ephemeral_port);
     Nan::SetPrototypeMethod (tpl, "setEvasiveTimeout", _set_evasive_timeout);
     Nan::SetPrototypeMethod (tpl, "setExpiredTimeout", _set_expired_timeout);
     Nan::SetPrototypeMethod (tpl, "setInterval", _set_interval);
@@ -191,6 +192,24 @@ NAN_METHOD (Zyre::_set_port) {
     else
         return Nan::ThrowTypeError ("`port nbr` must be a number");
     zyre_set_port (zyre->self, (int) port_nbr);
+}
+
+NAN_METHOD (Zyre::_set_ephemeral_port) {
+    Zyre *zyre = Nan::ObjectWrap::Unwrap <Zyre> (info.Holder ());
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `port nbr`");
+
+    //int port_nbr; // bjornw typedef - if using c_type, then you get 'int * major' but it needs to be 'int major'. later using the FromJust() returns an int
+    int port_nbr;
+
+
+    if (info [0]->IsNumber ())
+    {
+          port_nbr = Nan::To<int>(info [0]).FromJust ();
+    }
+    else
+        return Nan::ThrowTypeError ("`port nbr` must be a number");
+    zyre_set_ephemeral_port (zyre->self, (int) port_nbr);
 }
 
 NAN_METHOD (Zyre::_set_evasive_timeout) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -48,6 +48,7 @@ class Zyre: public Nan::ObjectWrap {
     static NAN_METHOD (_set_header);
     static NAN_METHOD (_set_verbose);
     static NAN_METHOD (_set_port);
+    static NAN_METHOD (_set_ephemeral_port);
     static NAN_METHOD (_set_evasive_timeout);
     static NAN_METHOD (_set_expired_timeout);
     static NAN_METHOD (_set_interval);

--- a/bindings/python/zyre/_zyre_ctypes.py
+++ b/bindings/python/zyre/_zyre_ctypes.py
@@ -82,6 +82,8 @@ lib.zyre_set_verbose.restype = None
 lib.zyre_set_verbose.argtypes = [zyre_p]
 lib.zyre_set_port.restype = None
 lib.zyre_set_port.argtypes = [zyre_p, c_int]
+lib.zyre_set_ephemeral_port.restype = None
+lib.zyre_set_ephemeral_port.argtypes = [zyre_p, c_int]
 lib.zyre_set_evasive_timeout.restype = None
 lib.zyre_set_evasive_timeout.argtypes = [zyre_p, c_int]
 lib.zyre_set_expired_timeout.restype = None
@@ -240,6 +242,14 @@ that so you can create independent clusters on the same network, for
 e.g. development vs. production. Has no effect after zyre_start().
         """
         return lib.zyre_set_port(self._as_parameter_, port_nbr)
+
+    def set_ephemeral_port(self, port_nbr):
+        """
+        Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+This call overrides this, to bypass some firewall issues when ports are
+random. Has no effect after zyre_start().
+        """
+        return lib.zyre_set_ephemeral_port(self._as_parameter_, port_nbr)
 
     def set_evasive_timeout(self, interval):
         """

--- a/bindings/python_cffi/zyre_cffi/Zyre.py
+++ b/bindings/python_cffi/zyre_cffi/Zyre.py
@@ -69,6 +69,14 @@ class Zyre(object):
         """
         utils.lib.zyre_set_port(self._p, port_nbr)
 
+    def set_ephemeral_port(self, port_nbr):
+        """
+        Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+        This call overrides this, to bypass some firewall issues when ports are
+        random. Has no effect after zyre_start().
+        """
+        utils.lib.zyre_set_ephemeral_port(self._p, port_nbr)
+
     def set_evasive_timeout(self, interval):
         """
         Set the peer evasiveness timeout, in milliseconds. Default is 5000.

--- a/bindings/python_cffi/zyre_cffi/cdefs.py
+++ b/bindings/python_cffi/zyre_cffi/cdefs.py
@@ -4105,6 +4105,12 @@ void
 void
     zyre_set_port (zyre_t *self, int port_nbr);
 
+// Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+// This call overrides this, to bypass some firewall issues when ports are
+// random. Has no effect after zyre_start().
+void
+    zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+
 // Set the peer evasiveness timeout, in milliseconds. Default is 5000.
 // This can be tuned in order to deal with expected network conditions
 // and the response time expected by the application. This is tied to

--- a/bindings/qml/src/QmlZyre.cpp
+++ b/bindings/qml/src/QmlZyre.cpp
@@ -51,6 +51,14 @@ void QmlZyre::setPort (int portNbr) {
 };
 
 ///
+//  Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+//  This call overrides this, to bypass some firewall issues when ports are
+//  random. Has no effect after zyre_start().
+void QmlZyre::setEphemeralPort (int portNbr) {
+    zyre_set_ephemeral_port (self, portNbr);
+};
+
+///
 //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
 //  This can be tuned in order to deal with expected network conditions
 //  and the response time expected by the application. This is tied to

--- a/bindings/qml/src/QmlZyre.h
+++ b/bindings/qml/src/QmlZyre.h
@@ -52,6 +52,11 @@ public slots:
     //  e.g. development vs. production. Has no effect after zyre_start().
     void setPort (int portNbr);
 
+    //  Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+    //  This call overrides this, to bypass some firewall issues when ports are
+    //  random. Has no effect after zyre_start().
+    void setEphemeralPort (int portNbr);
+
     //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
     //  This can be tuned in order to deal with expected network conditions
     //  and the response time expected by the application. This is tied to

--- a/bindings/qt/src/qzyre.cpp
+++ b/bindings/qt/src/qzyre.cpp
@@ -88,6 +88,16 @@ void QZyre::setPort (int portNbr)
 }
 
 ///
+//  Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+//  This call overrides this, to bypass some firewall issues when ports are
+//  random. Has no effect after zyre_start().
+void QZyre::setEphemeralPort (int portNbr)
+{
+    zyre_set_ephemeral_port (self, portNbr);
+
+}
+
+///
 //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
 //  This can be tuned in order to deal with expected network conditions
 //  and the response time expected by the application. This is tied to

--- a/bindings/ruby/lib/zyre/ffi.rb
+++ b/bindings/ruby/lib/zyre/ffi.rb
@@ -61,6 +61,7 @@ module Zyre
       attach_function :zyre_set_header, [:pointer, :string, :string, :varargs], :void, **opts
       attach_function :zyre_set_verbose, [:pointer], :void, **opts
       attach_function :zyre_set_port, [:pointer, :int], :void, **opts
+      attach_function :zyre_set_ephemeral_port, [:pointer, :int], :void, **opts
       attach_function :zyre_set_evasive_timeout, [:pointer, :int], :void, **opts
       attach_function :zyre_set_expired_timeout, [:pointer, :int], :void, **opts
       attach_function :zyre_set_interval, [:pointer, :size_t], :void, **opts

--- a/bindings/ruby/lib/zyre/ffi/zyre.rb
+++ b/bindings/ruby/lib/zyre/ffi/zyre.rb
@@ -167,6 +167,20 @@ module Zyre
         result
       end
 
+      # Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+      # This call overrides this, to bypass some firewall issues when ports are
+      # random. Has no effect after zyre_start().
+      #
+      # @param port_nbr [Integer, #to_int, #to_i]
+      # @return [void]
+      def set_ephemeral_port(port_nbr)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        port_nbr = Integer(port_nbr)
+        result = ::Zyre::FFI.zyre_set_ephemeral_port(self_p, port_nbr)
+        result
+      end
+
       # Set the peer evasiveness timeout, in milliseconds. Default is 5000.
       # This can be tuned in order to deal with expected network conditions
       # and the response time expected by the application. This is tied to

--- a/builds/check_zproject/ci_build.sh
+++ b/builds/check_zproject/ci_build.sh
@@ -22,7 +22,7 @@ fi
 if ! ((command -v dpkg-query >/dev/null 2>&1 && dpkg-query --list generator-scripting-language >/dev/null 2>&1) || \
        (command -v brew >/dev/null 2>&1 && brew ls --versions gsl >/dev/null 2>&1)); then
     cd "$REPO_DIR/.."
-    git clone https://github.com/imatix/gsl.git gsl
+    git clone https://github.com/zeromq/gsl.git gsl
     cd gsl/src
     make
     PATH="`pwd`:$PATH"

--- a/builds/msvc/vs2010/build.bat
+++ b/builds/msvc/vs2010/build.bat
@@ -18,6 +18,7 @@ SET solution=zyre.sln
 SET version=10
 SET log=build.log
 SET tools=Microsoft Visual Studio %version%.0\VC\vcvarsall.bat
+if "%version%" == "15" SET tools=Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
 SET environment="%programfiles(x86)%\%tools%"
 IF NOT EXIST %environment% SET environment="%programfiles%\%tools%"
 IF NOT EXIST %environment% GOTO no_tools

--- a/builds/msvc/vs2010/perf_local/perf_local.vcxproj
+++ b/builds/msvc/vs2010/perf_local/perf_local.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-208025084}</ProjectGuid>
     <ProjectName>perf_local</ProjectName>

--- a/builds/msvc/vs2010/perf_remote/perf_remote.vcxproj
+++ b/builds/msvc/vs2010/perf_remote/perf_remote.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-117378661}</ProjectGuid>
     <ProjectName>perf_remote</ProjectName>

--- a/builds/msvc/vs2010/zpinger/zpinger.vcxproj
+++ b/builds/msvc/vs2010/zpinger/zpinger.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-24137026}</ProjectGuid>
     <ProjectName>zpinger</ProjectName>

--- a/builds/msvc/vs2010/ztester_beacon/ztester_beacon.vcxproj
+++ b/builds/msvc/vs2010/ztester_beacon/ztester_beacon.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-255974958}</ProjectGuid>
     <ProjectName>ztester_beacon</ProjectName>

--- a/builds/msvc/vs2010/ztester_gossip/ztester_gossip.vcxproj
+++ b/builds/msvc/vs2010/ztester_gossip/ztester_gossip.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-254545520}</ProjectGuid>
     <ProjectName>ztester_gossip</ProjectName>

--- a/builds/msvc/vs2010/zyre_selftest/zyre_selftest.vcxproj
+++ b/builds/msvc/vs2010/zyre_selftest/zyre_selftest.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="10.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-170203828}</ProjectGuid>
     <ProjectName>zyre_selftest</ProjectName>

--- a/builds/msvc/vs2012/build.bat
+++ b/builds/msvc/vs2012/build.bat
@@ -18,6 +18,7 @@ SET solution=zyre.sln
 SET version=11
 SET log=build.log
 SET tools=Microsoft Visual Studio %version%.0\VC\vcvarsall.bat
+if "%version%" == "15" SET tools=Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
 SET environment="%programfiles(x86)%\%tools%"
 IF NOT EXIST %environment% SET environment="%programfiles%\%tools%"
 IF NOT EXIST %environment% GOTO no_tools

--- a/builds/msvc/vs2012/perf_local/perf_local.vcxproj
+++ b/builds/msvc/vs2012/perf_local/perf_local.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-208025084}</ProjectGuid>
     <ProjectName>perf_local</ProjectName>

--- a/builds/msvc/vs2012/perf_remote/perf_remote.vcxproj
+++ b/builds/msvc/vs2012/perf_remote/perf_remote.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-117378661}</ProjectGuid>
     <ProjectName>perf_remote</ProjectName>

--- a/builds/msvc/vs2012/zpinger/zpinger.vcxproj
+++ b/builds/msvc/vs2012/zpinger/zpinger.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-24137026}</ProjectGuid>
     <ProjectName>zpinger</ProjectName>

--- a/builds/msvc/vs2012/ztester_beacon/ztester_beacon.vcxproj
+++ b/builds/msvc/vs2012/ztester_beacon/ztester_beacon.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-255974958}</ProjectGuid>
     <ProjectName>ztester_beacon</ProjectName>

--- a/builds/msvc/vs2012/ztester_gossip/ztester_gossip.vcxproj
+++ b/builds/msvc/vs2012/ztester_gossip/ztester_gossip.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-254545520}</ProjectGuid>
     <ProjectName>ztester_gossip</ProjectName>

--- a/builds/msvc/vs2012/zyre_selftest/zyre_selftest.vcxproj
+++ b/builds/msvc/vs2012/zyre_selftest/zyre_selftest.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="11.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-170203828}</ProjectGuid>
     <ProjectName>zyre_selftest</ProjectName>

--- a/builds/msvc/vs2013/build.bat
+++ b/builds/msvc/vs2013/build.bat
@@ -18,6 +18,7 @@ SET solution=zyre.sln
 SET version=12
 SET log=build.log
 SET tools=Microsoft Visual Studio %version%.0\VC\vcvarsall.bat
+if "%version%" == "15" SET tools=Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
 SET environment="%programfiles(x86)%\%tools%"
 IF NOT EXIST %environment% SET environment="%programfiles%\%tools%"
 IF NOT EXIST %environment% GOTO no_tools

--- a/builds/msvc/vs2013/perf_local/perf_local.vcxproj
+++ b/builds/msvc/vs2013/perf_local/perf_local.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-208025084}</ProjectGuid>
     <ProjectName>perf_local</ProjectName>

--- a/builds/msvc/vs2013/perf_remote/perf_remote.vcxproj
+++ b/builds/msvc/vs2013/perf_remote/perf_remote.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-117378661}</ProjectGuid>
     <ProjectName>perf_remote</ProjectName>

--- a/builds/msvc/vs2013/zpinger/zpinger.vcxproj
+++ b/builds/msvc/vs2013/zpinger/zpinger.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-24137026}</ProjectGuid>
     <ProjectName>zpinger</ProjectName>

--- a/builds/msvc/vs2013/ztester_beacon/ztester_beacon.vcxproj
+++ b/builds/msvc/vs2013/ztester_beacon/ztester_beacon.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-255974958}</ProjectGuid>
     <ProjectName>ztester_beacon</ProjectName>

--- a/builds/msvc/vs2013/ztester_gossip/ztester_gossip.vcxproj
+++ b/builds/msvc/vs2013/ztester_gossip/ztester_gossip.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-254545520}</ProjectGuid>
     <ProjectName>ztester_gossip</ProjectName>

--- a/builds/msvc/vs2013/zyre_selftest/zyre_selftest.vcxproj
+++ b/builds/msvc/vs2013/zyre_selftest/zyre_selftest.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-170203828}</ProjectGuid>
     <ProjectName>zyre_selftest</ProjectName>

--- a/builds/msvc/vs2015/build.bat
+++ b/builds/msvc/vs2015/build.bat
@@ -18,6 +18,7 @@ SET solution=zyre.sln
 SET version=14
 SET log=build.log
 SET tools=Microsoft Visual Studio %version%.0\VC\vcvarsall.bat
+if "%version%" == "15" SET tools=Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat
 SET environment="%programfiles(x86)%\%tools%"
 IF NOT EXIST %environment% SET environment="%programfiles%\%tools%"
 IF NOT EXIST %environment% GOTO no_tools

--- a/builds/msvc/vs2015/perf_local/perf_local.vcxproj
+++ b/builds/msvc/vs2015/perf_local/perf_local.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-208025084}</ProjectGuid>
     <ProjectName>perf_local</ProjectName>

--- a/builds/msvc/vs2015/perf_remote/perf_remote.vcxproj
+++ b/builds/msvc/vs2015/perf_remote/perf_remote.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-117378661}</ProjectGuid>
     <ProjectName>perf_remote</ProjectName>

--- a/builds/msvc/vs2015/zpinger/zpinger.vcxproj
+++ b/builds/msvc/vs2015/zpinger/zpinger.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-24137026}</ProjectGuid>
     <ProjectName>zpinger</ProjectName>

--- a/builds/msvc/vs2015/ztester_beacon/ztester_beacon.vcxproj
+++ b/builds/msvc/vs2015/ztester_beacon/ztester_beacon.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-255974958}</ProjectGuid>
     <ProjectName>ztester_beacon</ProjectName>

--- a/builds/msvc/vs2015/ztester_gossip/ztester_gossip.vcxproj
+++ b/builds/msvc/vs2015/ztester_gossip/ztester_gossip.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-254545520}</ProjectGuid>
     <ProjectName>ztester_gossip</ProjectName>

--- a/builds/msvc/vs2015/zyre_selftest/zyre_selftest.vcxproj
+++ b/builds/msvc/vs2015/zyre_selftest/zyre_selftest.vcxproj
@@ -5,7 +5,7 @@
 #  Read the zproject/README.md for information about making permanent changes. #
 ################################################################################
 -->
-<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <ProjectGuid>{A5497C4B-1CD1-4779-9458-170203828}</ProjectGuid>
     <ProjectName>zyre_selftest</ProjectName>

--- a/doc/zyre.doc
+++ b/doc/zyre.doc
@@ -83,6 +83,12 @@ This is the class interface:
     ZYRE_EXPORT void
         zyre_set_port (zyre_t *self, int port_nbr);
     
+    // Set TCP beacon ephemeral port; defaults to 0, and the port is random.
+    // This call overrides this, to bypass some firewall issues with random ports.
+    // Has no effect after zyre_start().
+    ZYRE_EXPORT void
+        zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+
     //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
     //  This can be tuned in order to deal with expected network conditions
     //  and the response time expected by the application. This is tied to

--- a/doc/zyre.txt
+++ b/doc/zyre.txt
@@ -54,6 +54,12 @@ ZYRE_EXPORT void
 ZYRE_EXPORT void
     zyre_set_port (zyre_t *self, int port_nbr);
 
+// Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+// This call overrides this, to bypass some firewall issues when ports are
+// random. Has no effect after zyre_start().
+ZYRE_EXPORT void
+    zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+
 //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
 //  This can be tuned in order to deal with expected network conditions
 //  and the response time expected by the application. This is tied to

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -71,12 +71,6 @@ ZYRE_EXPORT void
 ZYRE_EXPORT void
     zyre_set_port (zyre_t *self, int port_nbr);
 
-// Set TCP beacon ephemeral port; defaults to 0 (the port is random).
-// This call overrides this, to bypass some firewall issues when ports are
-// random. Has no effect after zyre_start().
-ZYRE_EXPORT void
-    zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
-
 //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
 //  This can be tuned in order to deal with expected network conditions
 //  and the response time expected by the application. This is tied to
@@ -222,6 +216,13 @@ ZYRE_EXPORT void
     zyre_test (bool verbose);
 
 #ifdef ZYRE_BUILD_DRAFT_API
+//  *** Draft method, for development use, may change without warning ***
+//  Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+//  This call overrides this, to bypass some firewall issues when ports are
+//  random. Has no effect after zyre_start().
+ZYRE_EXPORT void
+    zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+
 //  *** Draft method, for development use, may change without warning ***
 //  This options enables a peer to actively contest for leadership in the
 //  given group. If this option is not set the peer will still participate in

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -71,6 +71,12 @@ ZYRE_EXPORT void
 ZYRE_EXPORT void
     zyre_set_port (zyre_t *self, int port_nbr);
 
+// Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+// This call overrides this, to bypass some firewall issues when ports are
+// random. Has no effect after zyre_start().
+ZYRE_EXPORT void
+    zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+
 //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
 //  This can be tuned in order to deal with expected network conditions
 //  and the response time expected by the application. This is tied to

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -206,6 +206,20 @@ zyre_set_port (zyre_t *self, int port_nbr)
 
 
 //  --------------------------------------------------------------------------
+//  Set TCP ephemeral port for beacon; defaults to 0, and the port is random.
+//  This call overrides this to bypass some firewall issues with random ports.
+//  Has no effect after zyre_start().
+
+void
+zyre_set_ephemeral_port (zyre_t *self, int port)
+{
+    assert (self);
+    zstr_sendm (self->actor, "SET EPHEMERAL PORT");
+    zstr_sendf (self->actor, "%d", port);
+}
+
+
+//  --------------------------------------------------------------------------
 //  Set the node evasiveness timeout, in milliseconds. Default is 5000.
 //  This can be tuned in order to deal with expected network conditions
 //  and the response time expected by the application. This is tied to

--- a/src/zyre_classes.h
+++ b/src/zyre_classes.h
@@ -61,6 +61,13 @@ typedef struct _zyre_node_t zyre_node_t;
 #ifndef ZYRE_BUILD_DRAFT_API
 
 //  *** Draft method, defined for internal use only ***
+//  Set TCP beacon ephemeral port; defaults to 0 (the port is random).
+//  This call overrides this, to bypass some firewall issues when ports are
+//  random. Has no effect after zyre_start().
+ZYRE_PRIVATE void
+    zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+
+//  *** Draft method, defined for internal use only ***
 //  This options enables a peer to actively contest for leadership in the
 //  given group. If this option is not set the peer will still participate in
 //  elections but never gets elected. This ensures that a consent for a leader

--- a/src/zyre_selftest.c
+++ b/src/zyre_selftest.c
@@ -22,8 +22,16 @@
 
 #include "zyre_classes.h"
 
-#include <stdio.h>
+#ifndef streq
+/*
+ *  Allow projects without czmq dependency:
+ *  The generated code expects that czmq pulls in a few headers and macro
+ *  definitions. This is a minimal fix for the generated selftest file in
+ *  C++ mode.
+ */
 #include <string.h>
+#define streq(s1,s2)    (!strcmp ((s1), (s2)))
+#endif
 
 typedef struct {
     const char *testname;           // test name, can be called from command line this way
@@ -61,7 +69,7 @@ test_available (const char *testname)
 {
     test_item_t *item;
     for (item = all_tests; item->testname; item++) {
-        if (strcmp (testname, item->testname) == 0)
+        if (streq (testname, item->testname))
             return item;
     }
     return NULL;
@@ -77,7 +85,7 @@ test_runall (bool verbose)
     test_item_t *item;
     printf ("Running zyre selftests...\n");
     for (item = all_tests; item->testname; item++) {
-        if (strcmp (item->testname, "private_classes") == 0)
+        if (streq (item->testname, "private_classes"))
             continue;
         if (!item->subtest)
             item->test (verbose);
@@ -109,7 +117,7 @@ test_number (void)
     int n = 0;
     test_item_t *item;
     for (item = all_tests; item->testname; item++) {
-        if (strcmp (item->testname, "private_classes") == 0)
+        if (! streq (item->testname, "private_classes"))
             n++;
     }
     printf ("%d\n", n);
@@ -122,8 +130,8 @@ main (int argc, char **argv)
     test_item_t *test = 0;
     int argn;
     for (argn = 1; argn < argc; argn++) {
-        if (strcmp (argv [argn], "--help") == 0
-        ||  strcmp (argv [argn], "-h") == 0) {
+        if (streq (argv [argn], "--help")
+        ||  streq (argv [argn], "-h")) {
             puts ("zyre_selftest.c [options] ...");
             puts ("  --verbose / -v         verbose test output");
             puts ("  --number / -n          report number of tests");
@@ -132,24 +140,24 @@ main (int argc, char **argv)
             puts ("  --continue / -c        continue on exception (on Windows)");
             return 0;
         }
-        if (strcmp (argv [argn], "--verbose") == 0
-        ||  strcmp (argv [argn], "-v") == 0)
+        if (streq (argv [argn], "--verbose")
+        ||  streq (argv [argn], "-v"))
             verbose = true;
         else
-        if (strcmp (argv [argn], "--number") == 0
-        ||  strcmp (argv [argn], "-n") == 0) {
+        if (streq (argv [argn], "--number")
+        ||  streq (argv [argn], "-n")) {
             test_number ();
             return 0;
         }
         else
-        if (strcmp (argv [argn], "--list") == 0
-        ||  strcmp (argv [argn], "-l") == 0) {
+        if (streq (argv [argn], "--list")
+        ||  streq (argv [argn], "-l")) {
             test_list ();
             return 0;
         }
         else
-        if (strcmp (argv [argn], "--test") == 0
-        ||  strcmp (argv [argn], "-t") == 0) {
+        if (streq (argv [argn], "--test")
+        ||  streq (argv [argn], "-t")) {
             argn++;
             if (argn >= argc) {
                 fprintf (stderr, "--test needs an argument\n");
@@ -162,8 +170,8 @@ main (int argc, char **argv)
             }
         }
         else
-        if (strcmp (argv [argn], "--continue") == 0
-        ||  strcmp (argv [argn], "-c") == 0) {
+        if (streq (argv [argn], "--continue")
+        ||  streq (argv [argn], "-c")) {
 #ifdef _MSC_VER
             //  When receiving an abort signal, only print to stderr (no dialog)
             _set_abort_behavior (0, _WRITE_ABORT_MSG);


### PR DESCRIPTION
This patch should allow to bypass firewalls on the same host than the ZYRE-application, when they use BEACON discovery.
See conversation on issue #323.

