### PR TITLE
Problem: #594 missed README.md, when renamed zyre_set_ephemeral_port().

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,11 +285,12 @@ This is the class interface:
     ZYRE_EXPORT void
         zyre_set_port (zyre_t *self, int port_nbr);
     
-    // Set TCP beacon ephemeral port; defaults to 0 (the port is random).
-    // This call overrides this, to bypass some firewall issues when ports are
-    // random. Has no effect after zyre_start().
+    //  Set the TCP port bound by the ROUTER peer-to-peer socket (beacon mode).
+    //  Defaults to * (the port is randomly assigned by the system).
+    //  This call overrides this, to bypass some firewall issues when ports are
+    //  random. Has no effect after zyre_start().
     ZYRE_EXPORT void
-        zyre_set_ephemeral_port (zyre_t *self, int port_nbr);
+        zyre_set_beacon_peer_port (zyre_t *self, int port_nbr);
     
     //  Set the peer evasiveness timeout, in milliseconds. Default is 5000.
     //  This can be tuned in order to deal with expected network conditions


### PR DESCRIPTION
Solution: Update README.md, accordingly (issue #595).
