### PR TITLE
Problem: draft beacon not compatible with non draft

### DIFF
--- a/include/zyre_library.h
+++ b/include/zyre_library.h
@@ -35,19 +35,6 @@
 #define ZYRE_VERSION \
     ZYRE_MAKE_VERSION(ZYRE_VERSION_MAJOR, ZYRE_VERSION_MINOR, ZYRE_VERSION_PATCH)
 
-// czmq_prelude.h bits
-
-// Windows MSVS doesn't have stdbool
-#if (defined (_MSC_VER) && !defined (true))
-#   if (!defined (__cplusplus) && (!defined (true)))
-#       define true 1
-#       define false 0
-        typedef char bool;
-#   endif
-#else
-#   include <stdbool.h>
-#endif
-// czmq_prelude.h bits
 
 #if defined (__WINDOWS__)
 #   if defined ZYRE_STATIC

--- a/src/zyre_classes.h
+++ b/src/zyre_classes.h
@@ -61,6 +61,9 @@ typedef struct _zyre_node_t zyre_node_t;
 //  *** To avoid double-definitions, only define if building without draft ***
 #ifndef ZYRE_BUILD_DRAFT_API
 
+//  *** Draft global constants, defined for internal use only ***
+#define ZAP_DOMAIN_DEFAULT  "global"           //  Default ZAP domain (auth)
+
 //  *** Draft method, defined for internal use only ***
 //  Set the TCP port bound by the ROUTER peer-to-peer socket (beacon mode).
 //  Defaults to * (the port is randomly assigned by the system).

--- a/src/zyre_group.c
+++ b/src/zyre_group.c
@@ -21,12 +21,10 @@
 struct _zyre_group_t {
     char *name;                 //  Group name
     zhash_t *peers;             //  Peers in group
-#ifdef ZYRE_BUILD_DRAFT_API
 //  DRAFT-API: Election
     bool contest;               //  Wheather the peer actively contest for leadership of this group
     zyre_peer_t *leader;        //  Peer that has been elected as leader for this group
     zyre_election_t *election;  //  Election handler, is NULL if there's no active election
-#endif
 };
 
 
@@ -49,10 +47,7 @@ zyre_group_new (const char *name, zhash_t *container)
     zyre_group_t *self = (zyre_group_t *) zmalloc (sizeof (zyre_group_t));
     self->name = strdup (name);
     self->peers = zhash_new ();
-#ifdef ZYRE_BUILD_DRAFT_API
-//  DRAFT-API: Election
     self->contest = false;
-#endif
 
     //  Insert into container if requested
     if (container) {
@@ -73,10 +68,7 @@ zyre_group_destroy (zyre_group_t **self_p)
     if (*self_p) {
         zyre_group_t *self = *self_p;
         zhash_destroy (&self->peers);
-#ifdef ZYRE_BUILD_DRAFT_API
-//  DRAFT-API: Election
         zyre_election_destroy (&self->election);
-#endif
         free (self->name);
         free (self);
         *self_p = NULL;
@@ -144,10 +136,6 @@ zyre_group_peers (zyre_group_t *self)
 {
     return zhash_keys (self->peers);
 }
-
-
-#ifdef ZYRE_BUILD_DRAFT_API
-//  DRAFT-API: Election
 
 //  --------------------------------------------------------------------------
 //  Find or create an election for a group
@@ -219,7 +207,6 @@ zyre_group_set_leader (zyre_group_t *self, zyre_peer_t *leader) {
     assert (self);
     self->leader = leader;
 }
-#endif
 
 
 //  --------------------------------------------------------------------------

--- a/src/zyre_group.h
+++ b/src/zyre_group.h
@@ -45,8 +45,6 @@ ZYRE_PRIVATE void
 ZYRE_PRIVATE zlist_t *
    zyre_group_peers (zyre_group_t *self);
 
-#ifdef ZYRE_BUILD_DRAFT_API
-//  DRAFT-API: Election
 //  Find or create an election for a group
 zyre_election_t *
     zyre_group_require_election (zyre_group_t *self);
@@ -73,7 +71,6 @@ zyre_peer_t *
 //  Sets the peer that has been elected leader of this group.
 void
     zyre_group_set_leader (zyre_group_t *self, zyre_peer_t *leader);
-#endif
 
 //  Self test of this class
 ZYRE_PRIVATE void

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -27,9 +27,7 @@ struct _zyre_node_t {
     bool verbose;               //  Log all traffic
     int beacon_port;            //  Beacon UDP port number
     char *ephemeral_port;         //  Beacon TCP ephemeral port number
-#ifdef ZYRE_BUILD_DRAFT_API
     byte beacon_version;        //  Beacon version
-#endif
     uint64_t evasive_timeout;   //  Time since a message is received before a peer is considered evasive
     uint64_t expired_timeout;   //  Time since a message is received before a peer is considered gone
     size_t interval;            //  Beacon interval
@@ -39,9 +37,7 @@ struct _zyre_node_t {
     zsock_t *inbox;             //  Our inbox socket (ROUTER)
     char *name;                 //  Our public name
     char *endpoint;             //  Our public endpoint
-#ifdef ZYRE_BUILD_DRAFT_API
     char *advertised_endpoint;  //  Our advertised public endpoint - NAT workaround?
-#endif
     int port;                   //  Our inbox port, if any
     byte status;                //  Our own change counter
     zhash_t *peers;             //  Hash of known peers, fast lookup
@@ -51,12 +47,9 @@ struct _zyre_node_t {
     zactor_t *gossip;           //  Gossip discovery service, if any
     char *gossip_bind;          //  Gossip bind endpoint, if any
     char *gossip_connect;       //  Gossip connect endpoint, if any
-
-#ifdef ZYRE_BUILD_DRAFT_API
     char *public_key;           // Our curve public key
     char *secret_key;           // Our curve private key
     char *zap_domain;           // ZAP domain if any
-#endif
 };
 
 //  Beacon frame has this format:
@@ -67,13 +60,9 @@ struct _zyre_node_t {
 //  port        2 bytes in network order
 //  curve key   32 bytes
 
-#ifdef ZYRE_BUILD_DRAFT_API
 #define BEACON_VERSION_V2 0x01
 #define BEACON_VERSION_V3 0x03
 #define BEACON_VERSION BEACON_VERSION_V2
-#else
-#define BEACON_VERSION 0x01
-#endif
 
 
 typedef struct {
@@ -81,10 +70,7 @@ typedef struct {
     byte version;
     byte uuid [ZUUID_LEN];
     uint16_t port;
-
-#ifdef ZYRE_BUILD_DRAFT_API
     uint8_t public_key [32];
-#endif
 } beacon_t;
 
 //  --------------------------------------------------------------------------
@@ -135,10 +121,9 @@ zyre_node_new (zsock_t *pipe, void *args)
     self->headers = zhash_new ();
     zhash_autofree (self->headers);
 
-#ifdef ZYRE_BUILD_DRAFT_API
     self->beacon_version = BEACON_VERSION_V2;
     self->zap_domain = strdup(ZAP_DOMAIN_DEFAULT);
-#endif
+
     //  Default name for node is first 6 characters of UUID:
     //  the shorter string is more readable in logs
     self->name = (char *) zmalloc (7);
@@ -169,12 +154,10 @@ zyre_node_destroy (zyre_node_t **self_p)
         zstr_free (&self->endpoint);
         zstr_free (&self->gossip_bind);
         zstr_free (&self->gossip_connect);
-#ifdef ZYRE_BUILD_DRAFT_API
         zstr_free (&self->secret_key);
         zstr_free (&self->public_key);
         zstr_free (&self->zap_domain);
         zstr_free (&self->advertised_endpoint);
-#endif
         zstr_free (&self->ephemeral_port);
         free (self->name);
         free (self);
@@ -201,7 +184,6 @@ zyre_node_gossip_start (zyre_node_t *self)
 static int
 zyre_node_start (zyre_node_t *self)
 {
-#ifdef ZYRE_BUILD_DRAFT_API
     if (self->secret_key) {
         // apply the cert to the socket
         if (self->verbose)
@@ -213,21 +195,18 @@ zyre_node_start (zyre_node_t *self)
         zsock_set_zap_domain (self->inbox, self->zap_domain);
         zcert_destroy(&cert);
     }
-#endif
 
     if (self->beacon_port) {
         //  Start beacon discovery
         //  ------------------------------------------------------------------
         assert (!self->beacon);
 
-#ifdef ZYRE_BUILD_DRAFT_API
         if (self->secret_key) {
             // upgrade the beacon version
             if (self->verbose)
                 zsys_debug ("switching to beacon v3");
             self->beacon_version = BEACON_VERSION_V3;
         }
-#endif
 
         self->beacon = zactor_new (zbeacon, NULL);
         if (!self->beacon)
@@ -254,7 +233,6 @@ zyre_node_start (zyre_node_t *self)
         }
         assert (self->gossip);
 
-#ifdef ZYRE_BUILD_DRAFT_API
         char *published_endpoint = strdup(self->endpoint);
 
         // if the advertised endpoint is set and different than our bound endpoint
@@ -275,17 +253,12 @@ zyre_node_start (zyre_node_t *self)
         zstr_sendx (self->gossip, "PUBLISH", zuuid_str (self->uuid), published_endpoint, NULL);
         zstr_free (&published_endpoint);
 
-#else
-        zstr_sendx (self->gossip, "PUBLISH", zuuid_str (self->uuid), self->endpoint, NULL);
-#endif
-
         //  Start polling on zgossip
         zpoller_add (self->poller, self->gossip);
         //  Start polling on inbox
         zpoller_add(self->poller, self->inbox);
     }
 
-#ifdef ZYRE_BUILD_DRAFT_API
     // this needs to be tested after bind
 #ifndef ZMQ_CURVE
         // legacy ZMQ support
@@ -294,7 +267,6 @@ zyre_node_start (zyre_node_t *self)
 #endif
     if (self->secret_key)
         assert (zsock_mechanism (self->inbox) == ZMQ_CURVE);
-#endif
 
     return 0;
 }
@@ -312,13 +284,9 @@ zyre_node_stop (zyre_node_t *self)
         beacon.protocol [0] = 'Z';
         beacon.protocol [1] = 'R';
         beacon.protocol [2] = 'E';
-#ifdef ZYRE_BUILD_DRAFT_API
         beacon.version = self->beacon_version;
         if (self->public_key)
             zmq_z85_decode(beacon.public_key, self->public_key);
-#else
-        beacon.version = BEACON_VERSION;
-#endif
         beacon.port = 0;            //  Zero means we're stopping
         zuuid_export (self->uuid, beacon.uuid);
         zsock_send (self->beacon, "sbi", "PUBLISH",
@@ -434,11 +402,9 @@ zyre_node_dump (zyre_node_t *self)
 
 //  Here we handle the different control messages from the front-end
 
-#ifdef ZYRE_BUILD_DRAFT_API
 // Forward declaration so that REQUIRE PEER works
 static zyre_peer_t *
 zyre_node_require_peer (zyre_node_t *self, zuuid_t *uuid, const char *endpoint, const char *public_key);
-#endif
 
 static void
 zyre_node_recv_api (zyre_node_t *self)
@@ -524,7 +490,6 @@ zyre_node_recv_api (zyre_node_t *self)
     if (streq (command, "SET ENDPOINT")) {
         zyre_node_gossip_start (self);
         char *endpoint = zmsg_popstr (request);
-#ifdef ZYRE_BUILD_DRAFT_API
         // when SET ENDPOINT is called, it calls zsock_bind
         // CURVE needs to be set before that happens
         // this happens when connecting nodes define the endpoint
@@ -539,7 +504,6 @@ zyre_node_recv_api (zyre_node_t *self)
             zsock_set_zap_domain (self->inbox, self->zap_domain);
             zcert_destroy(&cert);
         }
-#endif
         if (zsock_bind (self->inbox, "%s", endpoint) != -1) {
             zstr_free(&self->endpoint);
 #ifndef ZMQ_CURVE
@@ -547,11 +511,9 @@ zyre_node_recv_api (zyre_node_t *self)
             // inline incase the underlying assert is removed
             bool ZMQ_CURVE = false;
 #endif
-#ifdef ZYRE_BUILD_DRAFT_API
             // if we set a secret key- make sure the bind ZMQ_CURVE'd properly
             if (self->secret_key)
                 assert (zsock_mechanism (self->inbox) == ZMQ_CURVE);
-#endif
 
         self->endpoint = endpoint;
             zsock_signal (self->pipe, 0);
@@ -585,12 +547,10 @@ zyre_node_recv_api (zyre_node_t *self)
         zyre_node_gossip_start (self);
         zstr_free (&self->gossip_bind);
         self->gossip_bind = zmsg_popstr (request);
-#ifdef ZYRE_BUILD_DRAFT_API
         if (self->secret_key) {
             zstr_sendx(self->gossip, "SET SECRETKEY", self->secret_key, NULL);
             zstr_sendx(self->gossip, "SET PUBLICKEY", self->public_key, NULL);
         }
-#endif
         zstr_sendx (self->gossip, "BIND", self->gossip_bind, NULL);
     }
     else
@@ -598,22 +558,13 @@ zyre_node_recv_api (zyre_node_t *self)
         zyre_node_gossip_start (self);
         zstr_free (&self->gossip_connect);
         self->gossip_connect = zmsg_popstr (request);
-#ifdef ZYRE_BUILD_DRAFT_API
         if (self->secret_key) {
             zstr_sendx(self->gossip, "SET SECRETKEY", self->secret_key, NULL);
             zstr_sendx(self->gossip, "SET PUBLICKEY", self->public_key, NULL);
         }
         char *server_public_key = zmsg_popstr (request);
-        if (server_public_key)
-            zstr_sendx (self->gossip, "CONNECT", self->gossip_connect, server_public_key, NULL);
-        else
-            zstr_sendx (self->gossip, "CONNECT", self->gossip_connect, NULL);
-
+        zstr_sendx (self->gossip, "CONNECT", self->gossip_connect, server_public_key, NULL);
         zstr_free (&server_public_key);
-
-#else
-        zstr_sendx (self->gossip, "CONNECT", self->gossip_connect, NULL);
-#endif
     }
     else
     if (streq (command, "START"))
@@ -791,11 +742,7 @@ zyre_node_purge_peer (const char *key, void *item, void *argument)
 //  Find or create peer via its UUID
 
 static zyre_peer_t *
-#ifdef ZYRE_BUILD_DRAFT_API
 zyre_node_require_peer (zyre_node_t *self, zuuid_t *uuid, const char *endpoint, const char *public_key)
-#else
-zyre_node_require_peer (zyre_node_t *self, zuuid_t *uuid, const char *endpoint)
-#endif
 {
     assert (self);
     assert (endpoint);
@@ -811,7 +758,6 @@ zyre_node_require_peer (zyre_node_t *self, zuuid_t *uuid, const char *endpoint)
         peer = zyre_peer_new (self->peers, uuid);
         assert (peer);
 
-#ifdef ZYRE_BUILD_DRAFT_API
         if (self->public_key && self->secret_key) {
             assert (public_key != NULL);
             // set my local keys
@@ -821,7 +767,7 @@ zyre_node_require_peer (zyre_node_t *self, zuuid_t *uuid, const char *endpoint)
             // peer is acting as the 'server' curve role
             zyre_peer_set_server_key(peer, public_key);
         }
-#endif
+
         zyre_peer_set_origin (peer, self->name);
         zyre_peer_set_verbose (peer, self->verbose);
         int rc = zyre_peer_connect (peer, self->uuid, endpoint,
@@ -850,14 +796,10 @@ zyre_node_require_peer (zyre_node_t *self, zuuid_t *uuid, const char *endpoint)
             zre_msg_set_endpoint (msg, endpoint_iface);
         }
         else
-#ifdef ZYRE_BUILD_DRAFT_API
         if (self->advertised_endpoint)
             zre_msg_set_endpoint (msg, self->advertised_endpoint);
         else
             zre_msg_set_endpoint (msg, self->endpoint);
-#else
-        zre_msg_set_endpoint (msg, self->endpoint);
-#endif
 
         zre_msg_set_groups (msg, &groups);
         zre_msg_set_status (msg, self->status);
@@ -1020,7 +962,6 @@ zyre_node_recv_peer (zyre_node_t *self)
                 return;
             }
         }
-#ifdef ZYRE_BUILD_DRAFT_API
         if (!self->secret_key) {
             peer = zyre_node_require_peer (self, uuid, zre_msg_endpoint (msg), NULL);
         } else {
@@ -1035,9 +976,6 @@ zyre_node_recv_peer (zyre_node_t *self)
                 peer = NULL;
             }
         }
-#else
-        peer = zyre_node_require_peer (self, uuid, zre_msg_endpoint (msg));
-#endif
         if (peer)
             zyre_peer_set_ready (peer, true);
     }
@@ -1113,8 +1051,6 @@ zyre_node_recv_peer (zyre_node_t *self)
     if (zre_msg_id (msg) == ZRE_MSG_JOIN) {
         zyre_group_t *group = zyre_node_join_peer_group (self, peer, zre_msg_group (msg));
         assert (zre_msg_status (msg) == zyre_peer_status (peer));
-#ifdef ZYRE_BUILD_DRAFT_API
-//  DRAFT-API: Election
         if (zlist_exists (self->own_groups, (char *) zre_msg_group (msg))) {
             if (zyre_group_contest (zyre_node_require_peer_group (self, zre_msg_group (msg)))) {
                 //  Start election if there's an active election abort it
@@ -1137,14 +1073,11 @@ zyre_node_recv_peer (zyre_node_t *self)
                 zyre_group_send (group, &election_msg);
             }
         }
-#endif
     }
     else
     if (zre_msg_id (msg) == ZRE_MSG_LEAVE) {
         zyre_group_t *group = zyre_node_leave_peer_group (self, peer, zre_msg_group (msg));
         assert (zre_msg_status (msg) == zyre_peer_status (peer));
-#ifdef ZYRE_BUILD_DRAFT_API
-//  DRAFT-API: Election
         if (zlist_exists (self->own_groups, (char *) zre_msg_group (msg))) {
             zyre_peer_t *group_leader = zyre_group_leader (group);
             if (group_leader) {
@@ -1168,10 +1101,7 @@ zyre_node_recv_peer (zyre_node_t *self)
                 }
             }
         }
-#endif
     }
-#ifdef ZYRE_BUILD_DRAFT_API
-//  DRAFT-API: Election
     else
     if (zre_msg_id (msg) == ZRE_MSG_ELECT) {
         zyre_group_t *group = zyre_node_require_peer_group (self, zre_msg_group (msg));
@@ -1286,7 +1216,6 @@ zyre_node_recv_peer (zyre_node_t *self)
             zyre_group_set_election (group, NULL);
         }
     }
-#endif
     zuuid_destroy (&uuid);
     zre_msg_destroy (&msg);
 
@@ -1314,7 +1243,6 @@ zyre_node_recv_beacon (zyre_node_t *self)
     if (zframe_size (frame) == sizeof (beacon_t))
         memcpy (&beacon, zframe_data (frame), zframe_size (frame));
     zframe_destroy (&frame);
-#ifdef ZYRE_BUILD_DRAFT_API
     if (beacon.version != self->beacon_version) {
         zstr_free (&ipaddress);
         if (self->verbose)
@@ -1332,24 +1260,12 @@ zyre_node_recv_beacon (zyre_node_t *self)
         return;
     }
 
-#else
-    if (beacon.version != BEACON_VERSION) {
-        zstr_free (&ipaddress);
-        if (self->verbose)
-            zsys_debug ("tossing beacon");
-
-        return;                 //  Garbage beacon, ignore it
-    }
-
-#endif
-
     zuuid_t *uuid = zuuid_new ();
     zuuid_set (uuid, beacon.uuid);
     if (beacon.port) {
         char endpoint [NI_MAXHOST];
         sprintf (endpoint, "tcp://%s:%d", ipaddress, ntohs (beacon.port));
 
-#ifdef ZYRE_BUILD_DRAFT_API
         if (beacon.version == BEACON_VERSION_V3) {
             char public_key [41];
             zmq_z85_encode(public_key, beacon.public_key, 32);
@@ -1357,10 +1273,6 @@ zyre_node_recv_beacon (zyre_node_t *self)
         }
         else
             zyre_node_require_peer(self, uuid, endpoint, NULL);
-
-#else
-        zyre_node_require_peer (self, uuid, endpoint);
-#endif
     }
     else {
         //  Zero port means peer is going away; remove it if
@@ -1390,7 +1302,6 @@ zyre_node_recv_gossip (zyre_node_t *self)
     //  messages come from zgossip, not an external source
     assert (streq (command, "DELIVER"));
 
-#ifdef ZYRE_BUILD_DRAFT_API
     // extract public key from published service
     // tcp://endpoint:NNNN|asdfasdfasdfasdfasdf
     // do this before we check the endpoint o/w it will not match..
@@ -1400,23 +1311,14 @@ zyre_node_recv_gossip (zyre_node_t *self)
         *pipe = '\0';
         public_key = pipe+1;
     }
-#endif
 
     //  Require peer, if it's not us
-#ifdef ZYRE_BUILD_DRAFT_API
     // check to see if the endpoint and advertised endpoint are the same (NAT checking)
     if ((strneq (endpoint, self->endpoint))
         && (!self->advertised_endpoint || (strneq (endpoint, self->advertised_endpoint)))) {
-#else
-    if (strneq (endpoint, self->endpoint)) {
-#endif
         zuuid_t *uuid = zuuid_new ();
         zuuid_set_str (uuid, uuidstr);
-#ifdef ZYRE_BUILD_DRAFT_API
         zyre_node_require_peer (self, uuid, endpoint, public_key);
-#else
-        zyre_node_require_peer (self, uuid, endpoint);
-#endif
         zuuid_destroy (&uuid);
     }
     zstr_free (&command);
@@ -1515,19 +1417,13 @@ zyre_node_actor (zsock_t *pipe, void *args)
                     beacon.protocol[0] = 'Z';
                     beacon.protocol[1] = 'R';
                     beacon.protocol[2] = 'E';
-#ifdef ZYRE_BUILD_DRAFT_API
                     beacon.version = self->beacon_version;
-#else
-                    beacon.version = BEACON_VERSION;
-#endif
                     beacon.port = htons(self->port);
                     zuuid_export(self->uuid, beacon.uuid);
-#ifdef ZYRE_BUILD_DRAFT_API
                     // SEND
                     if (self->public_key) {
                         zmq_z85_decode(beacon.public_key, self->public_key);
                     }
-#endif
                     zsock_send(self->beacon, "sbi", "PUBLISH",
                         (byte *)&beacon, sizeof(beacon_t), self->interval);
                     zsock_send(self->beacon, "sb", "SUBSCRIBE", (byte *) "ZRE", 3);

--- a/src/zyre_peer.c
+++ b/src/zyre_peer.c
@@ -33,12 +33,9 @@ struct _zyre_peer_t {
     uint16_t want_sequence;     //  Incoming message sequence
     zhash_t *headers;           //  Peer headers
     bool verbose;               //  Do we log traffic & failures?
-
-#ifdef ZYRE_BUILD_DRAFT_API
     char *public_key;     // curve public key
     char *secret_key;     // curve secret key
     char *server_key;     // curve server [remote endpoint] key
-#endif
 };
 
 
@@ -89,17 +86,14 @@ zyre_peer_destroy (zyre_peer_t **self_p)
         zuuid_destroy (&self->uuid);
         free (self->name);
         free (self->origin);
-#ifdef ZYRE_BUILD_DRAFT_API
         free (self->server_key);
         free (self->public_key);
         free (self->secret_key);
-#endif
         free (self);
         *self_p = NULL;
     }
 }
 
-#ifdef ZYRE_BUILD_DRAFT_API
 void
 zyre_peer_set_public_key (zyre_peer_t *self, const char *key)
 {
@@ -123,7 +117,6 @@ zyre_peer_set_server_key (zyre_peer_t *self, const char *key)
     free (self->server_key);
     self->server_key = strdup (key);
 }
-#endif
 
 //  --------------------------------------------------------------------------
 //  Connect peer mailbox
@@ -176,7 +169,6 @@ zyre_peer_connect (zyre_peer_t *self, zuuid_t *from, const char *endpoint, uint6
         strcat (endpoint_iface, endpoint);
     zrex_destroy (&rex);
 
-#ifdef ZYRE_BUILD_DRAFT_API
     if (self->server_key) {
         zcert_t *cert = zcert_new_from_txt(self->public_key, self->secret_key);
         zcert_apply(cert, self->mailbox);
@@ -190,7 +182,6 @@ zyre_peer_connect (zyre_peer_t *self, zuuid_t *from, const char *endpoint, uint6
 #endif
         assert (zsock_mechanism (self->mailbox) == ZMQ_CURVE);
     }
-#endif
 
     //  Connect through to peer node
     rc = zsock_connect (self->mailbox, "%s", endpoint_iface);

--- a/src/zyre_peer.h
+++ b/src/zyre_peer.h
@@ -120,8 +120,6 @@ ZYRE_PRIVATE uint16_t
 ZYRE_PRIVATE uint16_t
     zyre_peer_sent_sequence (zyre_peer_t *self);
 
-// private
-#ifdef ZYRE_BUILD_DRAFT_API
 // curve support
 ZYRE_PRIVATE void
     zyre_peer_set_server_key (zyre_peer_t *self, const char *key);
@@ -131,7 +129,6 @@ ZYRE_PRIVATE void
 
 ZYRE_PRIVATE void
     zyre_peer_set_secret_key (zyre_peer_t *self, const char *key);
-#endif
 
 //  Self test of this class
 ZYRE_PRIVATE void


### PR DESCRIPTION
Solution: don't send empty public key in beacon in legacy mode. Also simplify internal code by removing unneeded ifdefs and add curve mode to zpinger.