### PR TITLE
Problem: build with non-DRAFT CZMQ broken

### DIFF
--- a/bindings/python_cffi/zyre_cffi/cdefs.py
+++ b/bindings/python_cffi/zyre_cffi/cdefs.py
@@ -3841,6 +3841,38 @@ void
 int
     zsys_auto_use_fd (void);
 
+// Print formatted string. Format is specified by variable names
+// in Python-like format style
+//
+// "%(KEY)s=%(VALUE)s", KEY=key, VALUE=value
+// become
+// "key=value"
+//
+// Returns freshly allocated string or NULL in a case of error.
+// Not enough memory, invalid format specifier, name not in args
+char *
+    zsys_zprintf (const char *format, zhash_t *args);
+
+// Return error string for given format/args combination.
+char *
+    zsys_zprintf_error (const char *format, zhash_t *args);
+
+// Print formatted string. Format is specified by variable names
+// in Python-like format style
+//
+// "%(KEY)s=%(VALUE)s", KEY=key, VALUE=value
+// become
+// "key=value"
+//
+// Returns freshly allocated string or NULL in a case of error.
+// Not enough memory, invalid format specifier, name not in args
+char *
+    zsys_zplprintf (const char *format, zconfig_t *args);
+
+// Return error string for given format/args combination.
+char *
+    zsys_zplprintf_error (const char *format, zconfig_t *args);
+
 // Set log identity, which is a string that prefixes all log messages sent
 // by this process. The log identity defaults to the environment variable
 // ZSYS_LOGIDENT, if that is set.

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -195,7 +195,10 @@ zyre_node_start (zyre_node_t *self)
         if (self->verbose)
             zsys_debug ("applying zcert to ->inbox");
 
-        zcert_t *cert = zcert_new_from_txt(self->public_key, self->secret_key);
+        uint8_t pub[32] = { 0 }, sec[32] = { 0 };
+        assert (zmq_z85_decode (pub, self->public_key));
+        assert (zmq_z85_decode (sec, self->secret_key));
+        zcert_t *cert = zcert_new_from(pub, sec);
         zcert_apply(cert, self->inbox);
         zsock_set_curve_server (self->inbox, 1);
         zsock_set_zap_domain (self->inbox, self->zap_domain);
@@ -504,7 +507,10 @@ zyre_node_recv_api (zyre_node_t *self)
             if (self->verbose)
                 zsys_debug ("applying zcert to ->inbox");
 
-            zcert_t *cert = zcert_new_from_txt(self->public_key, self->secret_key);
+            uint8_t pub[32] = { 0 }, sec[32] = { 0 };
+            assert (zmq_z85_decode (pub, self->public_key));
+            assert (zmq_z85_decode (sec, self->secret_key));
+            zcert_t *cert = zcert_new_from(pub, sec);
             zcert_apply(cert, self->inbox);
             zsock_set_curve_server (self->inbox, 1);
             zsock_set_zap_domain (self->inbox, self->zap_domain);

--- a/src/zyre_peer.c
+++ b/src/zyre_peer.c
@@ -170,7 +170,10 @@ zyre_peer_connect (zyre_peer_t *self, zuuid_t *from, const char *endpoint, uint6
     zrex_destroy (&rex);
 
     if (self->server_key) {
-        zcert_t *cert = zcert_new_from_txt(self->public_key, self->secret_key);
+        uint8_t pub[32] = { 0 }, sec[32] = { 0 };
+        assert (zmq_z85_decode (pub, self->public_key));
+        assert (zmq_z85_decode (sec, self->secret_key));
+        zcert_t *cert = zcert_new_from(pub, sec);
         zcert_apply(cert, self->mailbox);
         zcert_destroy(&cert);
 


### PR DESCRIPTION
Solution: use only stable APIs, and while here regenerate out-of-date bindings