### PR TITLE
Problem: zproject requires that class name differs from project name

### DIFF
--- a/project.xml
+++ b/project.xml
@@ -7,6 +7,7 @@
     url = "https://github.com/zeromq/zyre"
     license = "MPLv2"
     repository = "https://github.com/zeromq/zyre"
+    unique_class_name = "0"
     >
     <include filename = "license.xml" />
     <version major = "2" minor = "0" patch = "1" />


### PR DESCRIPTION
Solution: declare that we do not care that project and class header names can collide

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Note: Matches https://github.com/zeromq/zproject/pull/1109