### PR TITLE
problem: zyre missing GOSSIP UNPUBLISH command

### DIFF
--- a/api/python_cffi.slurp
+++ b/api/python_cffi.slurp
@@ -139,6 +139,10 @@ void
 void
     zyre_gossip_connect_curve (zyre_t *self, const char *public_key, const char *format, ...);
 
+// Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+void
+    zyre_gossip_unpublish (zyre_t *self, const char *node);
+
 // Start node, after setting header values. When you start a node it
 // begins discovery and connection. Returns 0 if OK, -1 if it wasn't
 // possible to start the node.

--- a/api/zyre.api
+++ b/api/zyre.api
@@ -156,6 +156,11 @@
         <argument name = "format" type = "format" />
     </method>
 
+    <method name = "gossip unpublish" state = "draft">
+        Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+        <argument name = "node" type = "string" />
+    </method>
+
     <method name = "start">
         Start node, after setting header values. When you start a node it
         begins discovery and connection. Returns 0 if OK, -1 if it wasn't

--- a/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
+++ b/bindings/jni/src/main/c/org_zeromq_zyre_Zyre.c
@@ -170,6 +170,14 @@ Java_org_zeromq_zyre_Zyre__1_1gossipConnectCurve (JNIEnv *env, jclass c, jlong s
     (*env)->ReleaseStringUTFChars (env, format, format_);
 }
 
+JNIEXPORT void JNICALL
+Java_org_zeromq_zyre_Zyre__1_1gossipUnpublish (JNIEnv *env, jclass c, jlong self, jstring node)
+{
+    char *node_ = (char *) (*env)->GetStringUTFChars (env, node, NULL);
+    zyre_gossip_unpublish ((zyre_t *) (intptr_t) self, node_);
+    (*env)->ReleaseStringUTFChars (env, node, node_);
+}
+
 JNIEXPORT jint JNICALL
 Java_org_zeromq_zyre_Zyre__1_1start (JNIEnv *env, jclass c, jlong self)
 {

--- a/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
+++ b/bindings/jni/src/main/java/org/zeromq/zyre/Zyre.java
@@ -210,6 +210,13 @@ public class Zyre implements AutoCloseable{
         __gossipConnectCurve (self, publicKey, format);
     }
     /*
+    Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+    */
+    native static void __gossipUnpublish (long self, String node);
+    public void gossipUnpublish (String node) {
+        __gossipUnpublish (self, node);
+    }
+    /*
     Start node, after setting header values. When you start a node it
     begins discovery and connection. Returns 0 if OK, -1 if it wasn't
     possible to start the node.

--- a/bindings/lua_ffi/zyre_ffi.lua
+++ b/bindings/lua_ffi/zyre_ffi.lua
@@ -151,6 +151,10 @@ void
 void
     zyre_gossip_connect_curve (zyre_t *self, const char *public_key, const char *format, ...);
 
+// Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+void
+    zyre_gossip_unpublish (zyre_t *self, const char *node);
+
 // Start node, after setting header values. When you start a node it
 // begins discovery and connection. Returns 0 if OK, -1 if it wasn't
 // possible to start the node.

--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -210,6 +210,12 @@ nothing my_zyre.gossipConnectCurve (String, String)
 Set-up gossip discovery with CURVE enabled.
 
 ```
+nothing my_zyre.gossipUnpublish (String)
+```
+
+Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+
+```
 integer my_zyre.start ()
 ```
 

--- a/bindings/nodejs/binding.cc
+++ b/bindings/nodejs/binding.cc
@@ -52,6 +52,7 @@ NAN_MODULE_INIT (Zyre::Init) {
     Nan::SetPrototypeMethod (tpl, "gossipBind", _gossip_bind);
     Nan::SetPrototypeMethod (tpl, "gossipConnect", _gossip_connect);
     Nan::SetPrototypeMethod (tpl, "gossipConnectCurve", _gossip_connect_curve);
+    Nan::SetPrototypeMethod (tpl, "gossipUnpublish", _gossip_unpublish);
     Nan::SetPrototypeMethod (tpl, "start", _start);
     Nan::SetPrototypeMethod (tpl, "stop", _stop);
     Nan::SetPrototypeMethod (tpl, "join", _join);
@@ -394,6 +395,21 @@ NAN_METHOD (Zyre::_gossip_connect_curve) {
     format = *format_utf8;
          //} //bjornw end
     zyre_gossip_connect_curve (zyre->self, (const char *)public_key, "%s", format);
+}
+
+NAN_METHOD (Zyre::_gossip_unpublish) {
+    Zyre *zyre = Nan::ObjectWrap::Unwrap <Zyre> (info.Holder ());
+    char *node;
+    if (info [0]->IsUndefined ())
+        return Nan::ThrowTypeError ("method requires a `node`");
+    else
+    if (!info [0]->IsString ())
+        return Nan::ThrowTypeError ("`node` must be a string");
+    //else { // bjornw: remove brackets to keep scope
+    Nan::Utf8String node_utf8 (info [0].As<String>());
+    node = *node_utf8;
+         //} //bjornw end
+    zyre_gossip_unpublish (zyre->self, (const char *)node);
 }
 
 NAN_METHOD (Zyre::_start) {

--- a/bindings/nodejs/binding.h
+++ b/bindings/nodejs/binding.h
@@ -61,6 +61,7 @@ class Zyre: public Nan::ObjectWrap {
     static NAN_METHOD (_gossip_bind);
     static NAN_METHOD (_gossip_connect);
     static NAN_METHOD (_gossip_connect_curve);
+    static NAN_METHOD (_gossip_unpublish);
     static NAN_METHOD (_start);
     static NAN_METHOD (_stop);
     static NAN_METHOD (_join);

--- a/bindings/python/zyre/_zyre_ctypes.py
+++ b/bindings/python/zyre/_zyre_ctypes.py
@@ -108,6 +108,8 @@ lib.zyre_gossip_connect.restype = None
 lib.zyre_gossip_connect.argtypes = [zyre_p, c_char_p]
 lib.zyre_gossip_connect_curve.restype = None
 lib.zyre_gossip_connect_curve.argtypes = [zyre_p, c_char_p, c_char_p]
+lib.zyre_gossip_unpublish.restype = None
+lib.zyre_gossip_unpublish.argtypes = [zyre_p, c_char_p]
 lib.zyre_start.restype = c_int
 lib.zyre_start.argtypes = [zyre_p]
 lib.zyre_stop.restype = None
@@ -349,6 +351,12 @@ design, see the CZMQ zgossip class.
         Set-up gossip discovery with CURVE enabled.
         """
         return lib.zyre_gossip_connect_curve(self._as_parameter_, public_key, format, *args)
+
+    def gossip_unpublish(self, node):
+        """
+        Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+        """
+        return lib.zyre_gossip_unpublish(self._as_parameter_, node)
 
     def start(self):
         """

--- a/bindings/python_cffi/zyre_cffi/Zyre.py
+++ b/bindings/python_cffi/zyre_cffi/Zyre.py
@@ -176,6 +176,12 @@ class Zyre(object):
         """
         utils.lib.zyre_gossip_connect_curve(self._p, utils.to_bytes(public_key), format, )
 
+    def gossip_unpublish(self, node):
+        """
+        Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+        """
+        utils.lib.zyre_gossip_unpublish(self._p, utils.to_bytes(node))
+
     def start(self):
         """
         Start node, after setting header values. When you start a node it

--- a/bindings/python_cffi/zyre_cffi/cdefs.py
+++ b/bindings/python_cffi/zyre_cffi/cdefs.py
@@ -4218,6 +4218,10 @@ void
 void
     zyre_gossip_connect_curve (zyre_t *self, const char *public_key, const char *format, ...);
 
+// Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+void
+    zyre_gossip_unpublish (zyre_t *self, const char *node);
+
 // Start node, after setting header values. When you start a node it
 // begins discovery and connection. Returns 0 if OK, -1 if it wasn't
 // possible to start the node.

--- a/bindings/qml/src/QmlZyre.cpp
+++ b/bindings/qml/src/QmlZyre.cpp
@@ -158,6 +158,12 @@ void QmlZyre::gossipConnectCurve (const QString &publicKey, const QString &forma
 };
 
 ///
+//  Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+void QmlZyre::gossipUnpublish (const QString &node) {
+    zyre_gossip_unpublish (self, node.toUtf8().data());
+};
+
+///
 //  Start node, after setting header values. When you start a node it
 //  begins discovery and connection. Returns 0 if OK, -1 if it wasn't
 //  possible to start the node.

--- a/bindings/qml/src/QmlZyre.h
+++ b/bindings/qml/src/QmlZyre.h
@@ -120,6 +120,9 @@ public slots:
     //  Set-up gossip discovery with CURVE enabled.
     void gossipConnectCurve (const QString &publicKey, const QString &format);
 
+    //  Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+    void gossipUnpublish (const QString &node);
+
     //  Start node, after setting header values. When you start a node it
     //  begins discovery and connection. Returns 0 if OK, -1 if it wasn't
     //  possible to start the node.

--- a/bindings/qt/src/qzyre.cpp
+++ b/bindings/qt/src/qzyre.cpp
@@ -221,6 +221,14 @@ void QZyre::gossipConnectCurve (const QString &publicKey, const QString &param)
 }
 
 ///
+//  Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+void QZyre::gossipUnpublish (const QString &node)
+{
+    zyre_gossip_unpublish (self, node.toUtf8().data());
+
+}
+
+///
 //  Start node, after setting header values. When you start a node it
 //  begins discovery and connection. Returns 0 if OK, -1 if it wasn't
 //  possible to start the node.

--- a/bindings/ruby/lib/zyre/ffi.rb
+++ b/bindings/ruby/lib/zyre/ffi.rb
@@ -74,6 +74,7 @@ module Zyre
       attach_function :zyre_gossip_bind, [:pointer, :string, :varargs], :void, **opts
       attach_function :zyre_gossip_connect, [:pointer, :string, :varargs], :void, **opts
       attach_function :zyre_gossip_connect_curve, [:pointer, :string, :string, :varargs], :void, **opts
+      attach_function :zyre_gossip_unpublish, [:pointer, :string], :void, **opts
       attach_function :zyre_start, [:pointer], :int, **opts
       attach_function :zyre_stop, [:pointer], :void, **opts
       attach_function :zyre_join, [:pointer, :string], :int, **opts

--- a/bindings/ruby/lib/zyre/ffi/zyre.rb
+++ b/bindings/ruby/lib/zyre/ffi/zyre.rb
@@ -348,6 +348,17 @@ module Zyre
         result
       end
 
+      # Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+      #
+      # @param node [String, #to_s, nil]
+      # @return [void]
+      def gossip_unpublish(node)
+        raise DestroyedError unless @ptr
+        self_p = @ptr
+        result = ::Zyre::FFI.zyre_gossip_unpublish(self_p, node)
+        result
+      end
+
       # Start node, after setting header values. When you start a node it
       # begins discovery and connection. Returns 0 if OK, -1 if it wasn't
       # possible to start the node.

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -255,6 +255,11 @@ ZYRE_EXPORT void
     zyre_gossip_connect_curve (zyre_t *self, const char *public_key, const char *format, ...) CHECK_PRINTF (3);
 
 //  *** Draft method, for development use, may change without warning ***
+//  Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+ZYRE_EXPORT void
+    zyre_gossip_unpublish (zyre_t *self, const char *node);
+
+//  *** Draft method, for development use, may change without warning ***
 //  Explicitly connect to a peer
 ZYRE_EXPORT int
     zyre_require_peer (zyre_t *self, const char *uuid, const char *endpoint, const char *public_key);

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -10,7 +10,6 @@ libzyre.pc
 
 # + config files for mains (if any):
 
-
 # location designated for writing self-tests:
 selftest-rw/
 

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -414,6 +414,19 @@ zyre_gossip_connect_curve (zyre_t *self, const char *public_key, const char *for
     free (string);
 }
 
+//  --------------------------------------------------------------------------
+//  Inform gossip to remove a node from it's master (tuples) list
+//  Useful when tracking nodes activity across the mesh
+
+void
+zyre_gossip_unpublish (zyre_t *self, const char *node)
+{
+    assert (self);
+    assert (node);
+
+    zstr_sendx (self->actor, "GOSSIP UNPUBLISH", node, NULL);
+}
+
 
 //  --------------------------------------------------------------------------
 //  Start node, after setting header values. When you start a node it

--- a/src/zyre_classes.h
+++ b/src/zyre_classes.h
@@ -102,6 +102,11 @@ ZYRE_PRIVATE void
     zyre_gossip_connect_curve (zyre_t *self, const char *public_key, const char *format, ...) CHECK_PRINTF (3);
 
 //  *** Draft method, defined for internal use only ***
+//  Unpublish a GOSSIP node from local list, useful in removing nodes from list when they EXIT
+ZYRE_PRIVATE void
+    zyre_gossip_unpublish (zyre_t *self, const char *node);
+
+//  *** Draft method, defined for internal use only ***
 //  Explicitly connect to a peer
 ZYRE_PRIVATE int
     zyre_require_peer (zyre_t *self, const char *uuid, const char *endpoint, const char *public_key);

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -179,8 +179,6 @@ zyre_node_gossip_start (zyre_node_t *self)
         self->gossip = zactor_new (zgossip, self->name);
         if (self->verbose)
             zstr_send (self->gossip, "VERBOSE");
-
-        zstr_sendx (self->gossip, "SET server/timeout", "60000", NULL);
         assert (self->gossip);
     }
 }


### PR DESCRIPTION
solution: add it since ZYRE already takes care of node staleness (pings/pongs/evasive/EXIT)

in your application code when you see an EXIT (and you're using gossip) you just trigger an UNPUBLISH of the node (uuid) to remove the node from your local gossip cache IF you want to. that way when new nodes join, you're not re-broadcasting dead nodes to new connections.

a high level example of this in `wesyoung/pyzyre` is forthcoming for testing. hopefully one day this will be more baked into zgossip itself, wanted to start at the higher level and test (over the wide open internet) then push some of those ideas down into czmq as they mature.

reference (and merge PRE-REQ): https://github.com/zeromq/czmq/pull/1943