### PR TITLE
zyre_set_endpoint supports ephemeral ports

### DIFF
--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -527,7 +527,8 @@ zyre_node_recv_api (zyre_node_t *self)
             if (self->secret_key)
                 assert (zsock_mechanism (self->inbox) == ZMQ_CURVE);
 
-        self->endpoint = endpoint;
+        self->endpoint = strdup(zsock_endpoint(self->inbox));
+		zstr_free(&endpoint);
             zsock_signal (self->pipe, 0);
         }
         else {


### PR DESCRIPTION
zyre_set_endpoint supports ephemeral ports. If didn't set an endpoint explicitly, it required every peer can access each other by hostname,that was a limit.
in zyre_node.c , 
`self->endpoint = endpoint;` 
to 
`
zstr_free(&endpoint);
self->endpoint = strdup(zsock_endpoint(self->inbox)); 
`

