### PR TITLE
zyre_event selftest needs zyre_set_endpoint on some systems

### DIFF
--- a/src/zyre_event.c
+++ b/src/zyre_event.c
@@ -285,6 +285,8 @@ zyre_event_test (bool verbose)
     zyre_t *node1 = zyre_new ("node1");
     assert (node1);
     zyre_set_header (node1, "X-HELLO", "World");
+    int rc = zyre_set_endpoint (node1, "inproc://zyre-node1");
+    assert (rc == 0);
     // use gossiping instead of beaconing, suits Travis better
     zyre_gossip_bind (node1, "inproc://gossip-hub");
     if (verbose)
@@ -300,9 +302,11 @@ zyre_event_test (bool verbose)
     assert (node2);
     if (verbose)
         zyre_set_verbose (node2);
+    rc = zyre_set_endpoint (node2, "inproc://zyre-node2");
+    assert (rc == 0);
     // use gossiping instead of beaconing, suits Travis better
     zyre_gossip_connect (node2, "inproc://gossip-hub");
-    int rc = zyre_start (node2);
+    rc = zyre_start (node2);
     assert (rc == 0);
     zyre_join (node2, "GLOBAL");
 


### PR DESCRIPTION
While the code as it is works fine on my Linux virtual machine, it fails on my MacOS laptop using nix.

Without a call to `zyre_set_endpoint`, upon joining, the gossip endpoint somehow resolves to `tcp://(null):49152` which fails to connect. Calling zyre_set_endpoint fixes it.