### PR TITLE
Problem: link error when only static lib is built

### DIFF
--- a/src/CMakeLists-local.txt
+++ b/src/CMakeLists-local.txt
@@ -2,9 +2,16 @@ add_executable(
     chat
     "${SOURCE_DIR}/examples/chat/chat.c"
 )
+
+if (TARGET zyre)
+    set(zyre_target zyre)
+else ()
+    set(zyre_target zyre-static)
+endif ()
+
 target_link_libraries(
     chat
-    zyre
+    ${zyre_target}
     ${LIBZMQ_LIBRARIES}
     ${CZMQ_LIBRARIES}
     ${OPTIONAL_LIBRARIES}


### PR DESCRIPTION
If `zyre` is built with:
> cmake .. -DZYRE_BUILD_SHARED=OFF -DZYRE_BUILD_STATIC=ON

there will be a link error when building `example/chat` as it tried to link against `zyre`.