### PR TITLE
Problem : the evasive event is not meaningful enough to detect possibly dead peers

### DIFF
--- a/api/zyre.api
+++ b/api/zyre.api
@@ -76,6 +76,18 @@
         <argument name = "interval" type = "integer" />
     </method>
 
+    <method name = "set silent timeout">
+        Set the peer silence timeout, in milliseconds. Default is 5000.
+        This can be tuned in order to deal with expected network conditions
+        and the response time expected by the application. This is tied to
+        the beacon interval and rate of messages received.
+        Silence is triggered one second after the timeout if peer has not
+        answered ping and has not sent any message.
+        NB: this is currently redundant with the evasiveness timeout. Both
+        affect the same timeout value.
+        <argument name = "interval" type = "integer" />
+    </method>
+
     <method name = "set expired timeout">
         Set the peer expiration timeout, in milliseconds. Default is 30000.
         This can be tuned in order to deal with expected network conditions

--- a/examples/chat/chat.c
+++ b/examples/chat/chat.c
@@ -83,6 +83,9 @@ chat_actor (zsock_t *pipe, void *args)
             else
             if (streq (event, "EVASIVE"))
                 printf ("%s is being evasive\n", name);
+            else
+            if (streq (event, "SILENT"))
+                printf ("%s is being silent\n", name);
 
             free (event);
             free (peer);

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -78,6 +78,17 @@ ZYRE_EXPORT void
 ZYRE_EXPORT void
     zyre_set_evasive_timeout (zyre_t *self, int interval);
 
+//  Set the peer silence timeout, in milliseconds. Default is 5000.
+//  This can be tuned in order to deal with expected network conditions
+//  and the response time expected by the application. This is tied to
+//  the beacon interval and rate of messages received.
+//  Silence is triggered one second after the timeout if peer has not
+//  answered ping and has not sent any message.
+//  NB: this is currently redundant with the evasiveness timeout. Both
+//  affect the same timeout value.
+    ZYRE_EXPORT void
+        zyre_set_silent_timeout (zyre_t *self, int interval);
+
 //  Set the peer expiration timeout, in milliseconds. Default is 30000.
 //  This can be tuned in order to deal with expected network conditions
 //  and the response time expected by the application. This is tied to

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -26,7 +26,9 @@
         ENTER fromnode name headers ipaddress:port
             a new peer has entered the network
         EVASIVE fromnode name
-            a peer is being evasive (quiet for too long)
+            a peer is being evasive (i.e. quiet) and will be pinged manually
+        SILENT fromnode name
+            a peer has been quiet and has not answered ping after 1 second
         EXIT fromnode name
             a peer has left the network
         JOIN fromnode name groupname
@@ -229,6 +231,25 @@ zyre_set_evasive_timeout (zyre_t *self, int interval)
 {
     assert (self);
     zstr_sendm (self->actor, "SET EVASIVE TIMEOUT");
+    zstr_sendf (self->actor, "%d", interval);
+}
+
+//  --------------------------------------------------------------------------
+//  Set the node silence timeout, in milliseconds. Default is 5000.
+//  Silence means that a peer does not send messages and does not
+//  answer to ping. SILENT event is triggered one second after the
+//  configured silence timeout, and every second after that until
+//  the expired timeout is reached.
+//  This can be tuned in order to deal with expected network conditions
+//  and the response time expected by the application. This is tied to
+//  the beacon interval and rate of messages received.
+//  NB: in current implementation, zyre_set_silent_timeout is redundant
+//  with zyre_set_evasive_timeout and calls the same code underneath.
+void
+zyre_set_silent_timeout (zyre_t *self, int interval)
+{
+    assert (self);
+    zstr_sendm (self->actor, "SET SILENT TIMEOUT");
     zstr_sendf (self->actor, "%d", interval);
 }
 

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -1370,25 +1370,27 @@ zyre_node_ping_peer (const char *key, void *item, void *argument)
             zsys_info ("(%s) peer expired name=%s endpoint=%s",
                 self->name, zyre_peer_name (peer), zyre_peer_endpoint (peer));
         zyre_node_remove_peer (self, peer);
+        return 0;
     }
     else
     if (zclock_mono () >= zyre_peer_evasive_at (peer)) {
-        //  If peer is being evasive, force a TCP ping.
         //  TODO: do this only once for a peer in this state;
         //  it would be nicer to use a proper state machine
         //  for peer management.
         if (self->verbose)
             zsys_info ("(%s) peer seems dead/slow name=%s endpoint=%s",
                 self->name, zyre_peer_name (peer), zyre_peer_endpoint (peer));
-        zre_msg_t *msg = zre_msg_new ();
-        zre_msg_set_id (msg, ZRE_MSG_PING);
-        zyre_peer_send (peer, &msg);
-        zre_msg_destroy (&msg);
         // Inform the calling application this peer is being evasive
         zstr_sendm (self->outbox, "EVASIVE");
         zstr_sendm (self->outbox, zyre_peer_identity (peer));
         zstr_send (self->outbox, zyre_peer_name (peer));
     }
+    
+    //actually ping peer
+    zre_msg_t *msg = zre_msg_new ();
+    zre_msg_set_id (msg, ZRE_MSG_PING);
+    zyre_peer_send (peer, &msg);
+    zre_msg_destroy (&msg);
     return 0;
 }
 


### PR DESCRIPTION
Solution : introduce a new SILENT event triggered one second after EVASIVE currently is if ping has not been answered.

NB: the EVASIVE event could safely be deprecated with this modification and that would avoid triggering an event that does not make sense if peer is just quiet for some time (which makes sense in many cases).