### PR TITLE
Fix Travis CI OSX Build of Python bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -183,7 +183,7 @@ matrix:
 before_install:
 - if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "android" ] ; then brew install binutils ; fi
 - if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "valgrind" ] ; then brew install valgrind ; fi
-- if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "bindings" -a "$BINDING" == "python" ] ; then brew upgrade python; brew install python@2 ; fi
+- if [ "$TRAVIS_OS_NAME" == "osx" -a "$BUILD_TYPE" == "bindings" -a "$BINDING" == "python" ] ; then brew upgrade python@3; brew upgrade python@2 ; fi
 
 # Hand off to generated script for each BUILD_TYPE
 ### Customization note: credentials and condition for deploy


### PR DESCRIPTION
OS X builds of the python bindings fail because the `python@2` homebrew package is already installed.

Before: https://travis-ci.org/zeromq/zyre/jobs/618737916
After: https://travis-ci.org/elijahr/zyre/jobs/627524241