### PR TITLE
Track return codes

### DIFF
--- a/src/zyre.c
+++ b/src/zyre.c
@@ -552,10 +552,15 @@ zyre_shout (zyre_t *self, const char *group, zmsg_t **msg_p)
     assert (group);
     assert (msg_p);
 
-    zstr_sendm (self->actor, "SHOUT");
-    zstr_sendm (self->actor, group);
-    zmsg_send (msg_p, self->actor);
-    return 0;
+    if (zstr_sendm (self->actor, "SHOUT") == -1) {
+        return -1;
+    }
+
+    if (zstr_sendm (self->actor, group) == -1) {
+        return -1;
+    }
+
+    return zmsg_send (msg_p, self->actor);
 }
 
 


### PR DESCRIPTION
Track return codes from zstr_sendm() and zmsg_send() in order to propagate errors through zyre_shout()

Exploratory pull request.

I was interested in tracking error codes when using zyre_shout(), however zyre_shout() always returns 0.

This is also the design behind other API calls like zyre_whisper().