### PR TITLE
Problem: Tossing beacon debug msg is unspecific

### DIFF
--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -1279,7 +1279,8 @@ zyre_node_recv_beacon (zyre_node_t *self)
     if (beacon.version != self->beacon_version) {
         zstr_free (&ipaddress);
         if (self->verbose)
-            zsys_debug ("tossing beacon, version mis-match");
+            zsys_debug ("tossing beacon, version mis-match. Got %d but expected %d.", beacon.version, self->beacon_version);
+
         return;
     }
 


### PR DESCRIPTION
Solution: Include the reason why the beacon was tossed. Meaning which
version was expected but which version was encountered.