### PR TITLE
Allow access to underlying raw ZMQ socket for cross library compatibility

### DIFF
--- a/include/zyre.h
+++ b/include/zyre.h
@@ -213,6 +213,10 @@ ZYRE_EXPORT char *
 ZYRE_EXPORT zsock_t *
     zyre_socket (zyre_t *self);
 
+//  Return ZMQ socket for talking to the Zyre node, for polling
+ZYRE_EXPORT void *
+    zyre_socket_zmq (zyre_t *self);
+
 //  Print zyre node information to stdout
 ZYRE_EXPORT void
     zyre_print (zyre_t *self);

--- a/src/zyre.c
+++ b/src/zyre.c
@@ -721,6 +721,13 @@ zyre_socket (zyre_t *self)
     return self->inbox;
 }
 
+void *zyre_socket_zmq (zyre_t *self)
+{
+    assert (self);
+
+    return zsock_resolve (self->inbox);
+}
+
 
 //  --------------------------------------------------------------------------
 //  Prints zyre node information


### PR DESCRIPTION
Hello,

I found when mixing libraries which are built upon czmq (like zyre) vs the raw libzmq library you can run into compatibility issues with polling and similar functions that need to look at the sockets for new data.

Zyre already exposes the czmq socket via zyre_socket so I propose another function zyre_socket_zmq that will expose the underlying zmq socket.

Adding this functionality allows easy mixing of the zyre library with some of the other C++ based libraries in the repo (most built on libzmq).