### PR TITLE
Documentation Update

### DIFF
--- a/api/zyre.api
+++ b/api/zyre.api
@@ -106,6 +106,8 @@
         Set network interface for UDP beacons. If you do not set this, CZMQ will
         choose an interface for you. On boxes with several interfaces you should
         specify which one you want to use, or strange things can happen.
+        The interface may by specified by either the interface name e.g. "eth0" or
+        an IP address associalted with the interface e.g. "192.168.0.1"
         <argument name = "value" type = "string" />
     </method>
 

--- a/include/zyre.h
+++ b/include/zyre.h
@@ -104,6 +104,8 @@ ZYRE_EXPORT void
 //  Set network interface for UDP beacons. If you do not set this, CZMQ will
 //  choose an interface for you. On boxes with several interfaces you should
 //  specify which one you want to use, or strange things can happen.
+//  The interface may by specified by either the interface name e.g. "eth0" or
+//  an IP address associalted with the interface e.g. "192.168.0.1"
 ZYRE_EXPORT void
     zyre_set_interface (zyre_t *self, const char *value);
 


### PR DESCRIPTION
Added a note in the comments that the interface when calling zyre_set_interface may now be specified with an adapter name OR an associated IP address. This behavior was added to czmq in this PR https://github.com/zeromq/czmq/pull/2062

I am unsure where else the documentation needs to be updated to explain this

