### PR TITLE
Problem: release script for OBS build fails often

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,10 @@ env:
     - secure: Dm9Hg0hqE1K9uDSrfW/fWj0ehzBTeevlP87J/d4bXQ2HHTqn7JoJpXFu2b0CkCquZ/raZIOQIXPA0heGmVyafNKIHl1Wotb1TVxB7VS6cLb67BxH9M7LIxwU2vPk/qpsSUGqRt73uDe6HNIqOQubokyWHJ/KwIDVCDa8sP1CpEs=
     - secure: LZxtiweZGsN2Eu1ck7yDBYDRmcE4+q7SWuFSUZzYeXhyZIilBCUwuvKa3FNkC3SwoUpBfZ+T5wyKfSvhZKFUn0p3FVykpbEZxpDCke5sclu9Q9uDP2t3926/Wf8kFT3NG51qxAJwgk9vXh5Rz9JcIlyPJY6/MCm5n/HBo+BpJ9A=
     - BINTRAY_USER_ORG=zeromq
-    # tokens to deploy releases on OBS and create/delete temporary branch on Github.
-    # 1) Create a token on https://github.com/settings/tokens/new with "public_repo"
-    #    capability and encrypt it with travis encrypt --org -r <org>/<repo> GH_TOKEN="<token>"
-    # 2) Create 2 OBS tokens with osc token --create network:messaging:zeromq:release-<stable|draft> <project>
+    # tokens to deploy releases on OBS.
+    # 1) Create 2 OBS tokens with osc token --create network:messaging:zeromq:release-<stable|draft> <project>
     #    encrypt them with travis encrypt --org -r <org>/<repo> OBS_<STABLE|DRAFT>_TOKEN="<token>"
-    # 3) Uncomment the three "secure" lines and paste the three generated hashed
+    # 2) Uncomment the three "secure" lines and paste the three generated hashed
     #    strings, which include each token's name, as parameters
     - secure: VmpVRSM7UNdF/P6CGac9r+yWYyngU/vBkI1IGPL6gTNm5ctAUzr+ni/3A4K9vHCLXEXFC2BX5XO050e09dw3U/jtG1n463E2JPW/sOmirQZl9N2RPU9fmT07mLWkpNKkPC7P0z/c37z2/xFlDQZ5gwIAnuMKLW1Gzg/XkTVCWh4=
     - secure: kjO5KenouBNcw41x0+7dLBZ4k/32/EQzx2nM4PbsblAODnnKxI6FDWh+25qvu8YFdItvuoRnISVRORWjEJYBBD6JhEbpCvlcn0tQ7RjeTT4mUEl03qrtEmYtjFJklZ1Wf6m1ZA3fokC1uzyaX4eF+vgO//v8j4UrHcSRrr3s2V0=

--- a/bindings/python_cffi/zyre_cffi/cdefs.py
+++ b/bindings/python_cffi/zyre_cffi/cdefs.py
@@ -2757,6 +2757,16 @@ bool
 void
     zsock_set_only_first_subscribe (void *self, int only_first_subscribe);
 
+// Set socket option `hello_msg`.
+// Available from libzmq 4.3.0.
+void
+    zsock_set_hello_msg (void *self, zframe_t *hello_msg);
+
+// Set socket option `disconnect_msg`.
+// Available from libzmq 4.3.0.
+void
+    zsock_set_disconnect_msg (void *self, zframe_t *disconnect_msg);
+
 // Set socket option `wss_trust_system`.
 // Available from libzmq 4.3.0.
 void

--- a/ci_deploy_obs.sh
+++ b/ci_deploy_obs.sh
@@ -8,15 +8,12 @@
 # do NOT set -x or it will log the secret tokens!
 set -e
 
-if [ "$BUILD_TYPE" == "default" -a -n "${GH_TOKEN}" -a -n "${OBS_STABLE_TOKEN}" -a -n "${OBS_DRAFT_TOKEN}" ]; then
-    # Trigger source run on new tag on OBS. See travis.yml for token instructions.
-    # We have to create a temporary branch from the tag and delete it, as it is
-    # not possible to edit files on OBS with secure tokens, and it is not
-    # possible to dynamically fetch the latest git tag either.
-    TAG_SHA=$(curl -s -H "Authorization: token ${GH_TOKEN}" -X GET https://api.github.com/repos/zeromq/zyre/git/refs/tags/${TRAVIS_TAG} | grep -o -P '(?<=sha":\s).*(?=,)')
-    curl -H "Authorization: token ${GH_TOKEN}" -X DELETE https://api.github.com/repos/zeromq/zyre/git/refs/heads/latest_release
-    curl -H "Authorization: token ${GH_TOKEN}" -X POST --data "{\"ref\":\"refs/heads/latest_release\",\"sha\":${TAG_SHA}}" https://api.github.com/repos/zeromq/zyre/git/refs
-    sleep 2 # try to avoid races if Github is slow
-    curl -H "Authorization: Token ${OBS_STABLE_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
-    curl -H "Authorization: Token ${OBS_DRAFT_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+if [ "$BUILD_TYPE" == "default" ] && [ -n "${OBS_STABLE_TOKEN}" -o -n "${OBS_DRAFT_TOKEN}" ]; then
+    # Trigger source run on new tag on OBS. The latest tag will be fetched.
+    if [ -n "${OBS_STABLE_TOKEN}" ]; then
+        curl -H "Authorization: Token ${OBS_STABLE_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+    fi
+    if [ -n "${OBS_DRAFT_TOKEN}" ]; then
+        curl -H "Authorization: Token ${OBS_DRAFT_TOKEN}" -X POST https://api.opensuse.org/trigger/runservice
+    fi
 fi

--- a/packaging/obs/_service
+++ b/packaging/obs/_service
@@ -2,6 +2,8 @@
   <service name="tar_scm">
     <param name="url">https://github.com/zeromq/zyre</param>
     <param name="scm">git</param>
+    <!-- delete to build from latest master on each refresh -->
+    <param name="revision">@PARENT_TAG@</param>
     <param name="versionformat">@PARENT_TAG@+git%cd</param>
     <param name="versionrewrite-pattern">v(.*)</param>
     <param name="versionrewrite-replacement">1</param>


### PR DESCRIPTION
Solution: now that tar_scm supports @PARENT_TAG@ as a revision to
automatically fetch the most recent tag on the default branch, use
it to simplify everything

https://github.com/openSUSE/obs-service-tar_scm/pull/359