### PR TITLE
Keep zre_msg.h in src directory

### DIFF
--- a/api/zyre_event.api
+++ b/api/zyre_event.api
@@ -24,7 +24,7 @@
 
     <method name = "type">
         Returns event type, as printable uppercase string. Choices are:
-        "ENTER", "EXIT", "JOIN", "LEAVE", "EVASIVE", "SILENT", "WHISPER" and "SHOUT"
+        "ENTER", "EXIT", "JOIN", "LEAVE", "EVASIVE", "WHISPER" and "SHOUT"
         and for the local node: "STOP"
         <return type = "string" />
     </method>

--- a/include/zyre_event.h
+++ b/include/zyre_event.h
@@ -36,7 +36,7 @@ ZYRE_EXPORT void
     zyre_event_destroy (zyre_event_t **self_p);
 
 //  Returns event type, as printable uppercase string. Choices are:
-//  "ENTER", "EXIT", "JOIN", "LEAVE", "EVASIVE", "SILENT", "WHISPER" and "SHOUT"
+//  "ENTER", "EXIT", "JOIN", "LEAVE", "EVASIVE", "WHISPER" and "SHOUT"
 //  and for the local node: "STOP"
 ZYRE_EXPORT const char *
     zyre_event_type (zyre_event_t *self);

--- a/include/zyre_event.h
+++ b/include/zyre_event.h
@@ -36,7 +36,7 @@ ZYRE_EXPORT void
     zyre_event_destroy (zyre_event_t **self_p);
 
 //  Returns event type, as printable uppercase string. Choices are:
-//  "ENTER", "EXIT", "JOIN", "LEAVE", "EVASIVE", "WHISPER" and "SHOUT"
+//  "ENTER", "EXIT", "JOIN", "LEAVE", "EVASIVE", "SILENT", "WHISPER" and "SHOUT"
 //  and for the local node: "STOP"
 ZYRE_EXPORT const char *
     zyre_event_type (zyre_event_t *self);

--- a/src/zre_msg.c
+++ b/src/zre_msg.c
@@ -35,7 +35,7 @@
 #endif
 
 #include "../include/zyre.h"
-#include "../include/zre_msg.h"
+#include "./zre_msg.h"
 
 //  Structure of our class
 

--- a/src/zre_msg.c
+++ b/src/zre_msg.c
@@ -1425,7 +1425,6 @@ zre_msg_encode (zre_msg_t *self)
             PUT_NUMBER1 (2);
             PUT_NUMBER2 (self->sequence);
             nbr_frames += self->content? zmsg_size (self->content): 1;
-            have_content = true;
             break;
 
         case ZRE_MSG_SHOUT:
@@ -1433,7 +1432,6 @@ zre_msg_encode (zre_msg_t *self)
             PUT_NUMBER2 (self->sequence);
             PUT_STRING (self->group);
             nbr_frames += self->content? zmsg_size (self->content): 1;
-            have_content = true;
             break;
 
         case ZRE_MSG_JOIN:

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -1308,10 +1308,9 @@ zyre_node_recv_peer (zyre_node_t *self)
     if (zre_msg_id (msg) == ZRE_MSG_GOODBYE) {
         //  If discovery mode is UDP, beacons do the job for peer removal (see zyre_node_recv_beacon)
         //  If discovery mode is Gossip, we need to remove here
-        if (self->gossip) {
-            zyre_peer_t *peer = (zyre_peer_t *) zhash_lookup (self->peers, zuuid_str (uuid));
-            if (peer)
-                zyre_node_remove_peer (self, peer);
+        if (self->gossip && peer) {
+            zyre_node_remove_peer (self, peer);
+            peer = NULL;
         }
     }
     
@@ -1319,7 +1318,8 @@ zyre_node_recv_peer (zyre_node_t *self)
     zre_msg_destroy (&msg);
 
     //  Activity from peer resets peer timers
-    zyre_peer_refresh (peer, self->evasive_timeout, self->expired_timeout);
+    if (peer)
+        zyre_peer_refresh (peer, self->evasive_timeout, self->expired_timeout);
 }
 
 //  Handle beacon data


### PR DESCRIPTION
This is a bug in automatic code generation which places all headers in include by default