### PR TITLE
Problem: linters want SPDX license shortnames

### DIFF
--- a/packaging/redhat/zyre.spec
+++ b/packaging/redhat/zyre.spec
@@ -38,7 +38,7 @@ Name:           zyre
 Version:        2.0.1
 Release:        1
 Summary:        an open-source framework for proximity-based p2p apps
-License:        MPLv2
+License:        MPL-2.0
 URL:            https://github.com/zeromq/zyre
 Source0:        %{name}-%{version}.tar.gz
 Group:          System/Libraries

--- a/project.xml
+++ b/project.xml
@@ -2,7 +2,7 @@
     name = "zyre"
     description = "an open-source framework for proximity-based P2P apps"
     script = "zproject.gsl"
-    license = "MPLv2"
+    license = "MPL-2.0"
     email = "zeromq-dev@lists.zeromq.org"
     url = "https://github.com/zeromq/zyre"
     license = "MPLv2"


### PR DESCRIPTION
Solution: use MPL-2.0 instead of MPLv2