### PR TITLE
Problem: Gradle version of JNI bindings is not updated automatically

### DIFF
--- a/bindings/jni/gradle/wrapper/gradle-wrapper.properties
+++ b/bindings/jni/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Solution: Manually update the gradle version from gradle-wrapper.properties