### PR TITLE
Problem : In gossip mode, when a peer enters the network after another peer exited and came back on same endpoint (with another uuid), the new node receives an endless loop of "ENTER" and "EXIT"

### DIFF
--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -917,7 +917,7 @@ zyre_node_remove_peer (zyre_node_t *self, zyre_peer_t *peer)
     
 #ifdef ZYRE_BUILD_DRAFT_API
     //  Clean this peer in our gossip table if needed
-    if (self->gossip_bind)
+    if (self->gossip)
         zstr_sendx (self->gossip, "UNPUBLISH", zyre_peer_identity (peer), NULL);
     
     //  Restart election if leaving peer was leader in a group

--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -276,7 +276,7 @@ zyre_node_start (zyre_node_t *self)
             zstr_free (&t1);
         }
 
-        zstr_sendx (self->gossip, "PUBLISH", zuuid_str (self->uuid), published_endpoint, NULL);
+        zstr_sendx (self->gossip, "PUBLISH", published_endpoint, zuuid_str (self->uuid), NULL);
         zstr_free (&published_endpoint);
 
         //  Start polling on zgossip
@@ -918,8 +918,8 @@ zyre_node_remove_peer (zyre_node_t *self, zyre_peer_t *peer)
 #ifdef ZYRE_BUILD_DRAFT_API
     //  Clean this peer in our gossip table if needed
     if (self->gossip)
-        zstr_sendx (self->gossip, "UNPUBLISH", zyre_peer_identity (peer), NULL);
-
+        zstr_sendx (self->gossip, "UNPUBLISH", zyre_peer_endpoint (peer), NULL);
+    
     //  Restart election if leaving peer was leader in a group
     const char *group_name = (const char *) zlist_first (self->own_groups);
     while (group_name) {
@@ -1463,9 +1463,9 @@ zyre_node_recv_beacon (zyre_node_t *self)
 static void
 zyre_node_recv_gossip (zyre_node_t *self)
 {
-    //  Get IP address and beacon of peer
-    char *command = NULL, *uuidstr, *endpoint;
-    zstr_recvx (self->gossip, &command, &uuidstr, &endpoint, NULL);
+    //  Get peer endpoint and  uuid
+    char *command = NULL, *endpoint, *uuidstr;
+    zstr_recvx (self->gossip, &command, &endpoint, &uuidstr, NULL);
     if (command == NULL)
         return;                 //  Interrupted
 


### PR DESCRIPTION
Solution : PUBLISH zyre nodes to gossip with their endpoints as tuple key and not their UUIDs so that tuples are properly stored in gossip tables.

By storing zyre nodes with their UUIDs as tuple keys, when a node re-enters the network, the other nodes will store 2 tuples in their gossip table. They keep the old one because the tuple key (UUID) is different. A new zyre node will then try to discover 2 peers with different UUID but the same endpoint which is incorrect and impossible.

By storing zyre nodes with their endpoints as tuple keys, other nodes will only store the last node that entered the network on a specific endpoint. Then, when a new node enters the network, it will try to discover only the last node for this endpoint, which the one currently alive.

In addition, publishing gossip tuples with an endpoint as a key corresponds to how tuples are stored in czmq zgossip tests