### PR TITLE
Problem: Invalid project.xml XML file.

### DIFF
--- a/project.xml
+++ b/project.xml
@@ -5,7 +5,6 @@
     license = "MPL-2.0"
     email = "zeromq-dev@lists.zeromq.org"
     url = "https://github.com/zeromq/zyre"
-    license = "MPL-2.0"
     repository = "https://github.com/zeromq/zyre"
     unique_class_name = "0"
     >


### PR DESCRIPTION
Failure detected with 'xmlstarlet' and 'xpath':
```
prompt> xmlstarlet val -w ./project.xml
./project.xml - invalid
prompt> xpath ./project.xml '/project/text()'

duplicate attribute at line 8, column 4, byte 242:
    email = "zeromq-dev@lists.zeromq.org"
    url = "https://github.com/zeromq/zyre"
    license = "MPL-2.0"
===^
    repository = "https://github.com/zeromq/zyre"
    unique_class_name = "0"
 at /usr/lib64/perl5/vendor_perl/XML/Parser.pm line 187.
prompt>
```

Confirmation:
```
<project
    name = "zyre"
    description = "an open-source framework for proximity-based P2P apps"
    script = "zproject.gsl"
    license = "MPL-2.0"                       <---
    email = "zeromq-dev@lists.zeromq.org"
    url = "https://github.com/zeromq/zyre"
    license = "MPL-2.0"                       <--- Duplicate entry.
    repository = "https://github.com/zeromq/zyre"
    unique_class_name = "0"
    >
```

Solution:
Remove the 2nd redundant entry.
Thankfully, both are identical.

Note #1:
> Introduced with #538 merge and fixed twice with
> - 0790f175f1593826acb80fbe7bf4f76d40c7c784
> - e13e99049f18192e9f98b0f7c67faf23eefdc53e
> :-)

Note #2:
> The same tools report also invalid XML for api/*.api files.
> Fixing both would change too much documentations...