### PR TITLE
Problem: JCENTER/BINTRAY no more available for Android repositories

### DIFF
--- a/bindings/jni/build.gradle
+++ b/bindings/jni/build.gradle
@@ -28,7 +28,11 @@ subprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
+        // BINTRAY no more responding.
+        // JFROG announced JCENTER & BINTRAY shutdown in 2021.
+        // - What to do for the JFROG plugin ?
+        // - Is the README still valid ?
+        /* jcenter() */
     }
 
     group = 'org.zeromq.zyre'


### PR DESCRIPTION
Solution: Remove JCENTER() call, from Android repository search path.

See
- ZPROJECT [issue 1314](https://github.com/zeromq/zproject/pull/1314) for more details.
- ZPROJECT [issue 1315](https://github.com/zeromq/zproject/pull/1315) for more questions.