### PR TITLE
Problem: Elections are restarted even if a non-leader (follower) peer left

### DIFF
--- a/src/zyre_node.c
+++ b/src/zyre_node.c
@@ -930,9 +930,8 @@ zyre_node_remove_peer (zyre_node_t *self, zyre_peer_t *peer)
                 group_leader
                 && streq (zyre_peer_identity (group_leader), zyre_peer_identity (peer));
         if (zyre_group_contest (group)
-            && (!election
-                || !zyre_election_lrec_complete(election, group)
-                || leader_left)) {
+            && ((election && !zyre_election_lrec_complete(election, group))
+                 || leader_left)) {
             // leader left: start elections in group
             if (election) {
                 //  Discard running election because the number of peers changed


### PR DESCRIPTION
The boolean expression checking if the elections must be re-evaluated upon a peer exit let a new election start even if it is not necessary.  
Elections must be restarted upon a peer exit when  
- there was an election running, so the current election is canceled and a new one starts
- there was no election running but the current leader left  

Previous code restarted elections on any peer exit when there was no election running.

Solution: Fix the boolean expression to re-start elections only on leader exit when there are no elections running.