### PR TITLE
ANDROID: Support NDK r27x (regen from zproject).

### DIFF
--- a/builds/android/android_build_helper.sh
+++ b/builds/android/android_build_helper.sh
@@ -328,8 +328,11 @@ function android_build_opts {
 
     _android_build_opts_process_binaries
 
-    # Since NDK r23 we don't need -lgcc due to LLVM being now the default
-    if [ ! -x "${TOOLCHAIN_PATH}/${TOOLCHAIN_HOST}-ar" ]; then
+    if [ ${NDK_NUMBER} -ge 2700 ] ; then
+        # Since NDK r27 symbols like '__aeabi_xxx' are no more exported in the dynamic lib.
+        export ANDROID_BUILD_LIBS="-lc -ldl -lm -llog -static-libstdc++"
+    elif [ ${NDK_NUMBER} -ge 2300 ] ; then
+        # Since NDK r23 we don't need -lgcc due to LLVM being now the default.
         export ANDROID_BUILD_LIBS="-lc -ldl -lm -llog -lc++_shared"
     else
         export ANDROID_BUILD_LIBS="-lc -lgcc -ldl -lm -llog -lc++_shared"


### PR DESCRIPTION
Problem: ZYRE cannot be built with NDK r27 and higher.

Solution: Regenerate this part from ZPROJECT.