### PR TITLE
Fix memory leak when peer drops suddenly

### DIFF
--- a/src/zre_msg.c
+++ b/src/zre_msg.c
@@ -1281,8 +1281,12 @@ zre_msg_send (zre_msg_t *self, zsock_t *output)
     }
 
     //  Now send the data frame
-    zmq_msg_send (&frame, zsock_resolve (output), --nbr_frames? ZMQ_SNDMORE: 0);
-
+    int num_bytes = zmq_msg_send (&frame, zsock_resolve (output), --nbr_frames? ZMQ_SNDMORE: 0);
+    if(num_bytes < 0) {
+        zmq_msg_close(&frame);
+        return -1;
+    }
+    
     //  Now send the content if necessary
     if (have_content) {
         if (self->content) {

--- a/src/zyre_peer.c
+++ b/src/zyre_peer.c
@@ -268,6 +268,7 @@ zyre_peer_send (zyre_peer_t *self, zre_msg_t **msg_p)
                     zsys_info ("(%s) disconnect from peer (EAGAIN): name=%s",
                         self->origin, self->name);
                 zyre_peer_disconnect (self);
+                zre_msg_destroy (msg_p);
                 return -1;
             }
             //  Can't get any other error here


### PR DESCRIPTION
This adds a check for zmq_msg_send and properly cleans up after any error conditions are met.

This leak was found with ASAN via a unit test that spun up a ton of peers, had them spam each other, and then they shutdown sequentially. 